### PR TITLE
[FIX] add line on false postal number

### DIFF
--- a/l10n_ch_dta/wizard/create_dta.py
+++ b/l10n_ch_dta/wizard/create_dta.py
@@ -166,7 +166,8 @@ class postal_record(record):
             raise orm.except_orm(
                 _('Error'),
                 _('Wrong postal number format.\n'
-                  'It must be 12-123456-9 or 12345 format')
+                  'It must be 12-123456-9 or 12345 format \n'
+                  'on line %s' % (self.pline.name))
             )
 
 


### PR DESCRIPTION
When user have an error on a large file dta file, it's better to have information on the line position in case of error
