### PR TITLE
l10n_ch_base_bank breaks onchange_partner_id on invoices

### DIFF
--- a/l10n_ch_base_bank/bank_view.xml
+++ b/l10n_ch_base_bank/bank_view.xml
@@ -4,7 +4,6 @@
     <record model="ir.ui.view" id="invoice_supplier_form8">
       <field name="name">account.invoice.supplier.form.inherit</field>
       <field name="model">account.invoice</field>
-      <field name="type">form</field>
       <field name="inherit_id" ref="account.invoice_supplier_form"/>
       <field name="priority" eval="18"/>
       <field name="arch" type="xml">
@@ -17,7 +16,6 @@
     <record model="ir.ui.view" id="invoice_form">
       <field name="name">account.invoice.form.inherit</field>
       <field name="model">account.invoice</field>
-      <field name="type">form</field>
       <field name="inherit_id" ref="account.invoice_form"/>
       <field name="arch" type="xml">
         <field name="partner_bank_id" position="attributes">
@@ -49,7 +47,6 @@
     <record model="ir.ui.view" id="add_custom_fields_on_bank">
       <field name="name">add custom fields on bank</field>
       <field name="model">res.bank</field>
-      <field name="type">form</field>
       <field name="inherit_id" ref="base.view_res_bank_form"/>
       <field name="arch" type="xml">
         <field name="bic" position="after">
@@ -63,7 +60,6 @@
     <record model="ir.ui.view" id="add_custom_fields_on_bank_list">
       <field name="name">add custom fields on bank list</field>
       <field name="model">res.bank</field>
-      <field name="type">form</field>
       <field name="inherit_id" ref="base.view_res_bank_tree"/>
       <field name="arch" type="xml">
         <field name="bic" position="after">
@@ -79,7 +75,6 @@
     <record model="ir.ui.view" id="add_ccp_on_res_partner_bank">
       <field name="name">Add ccp on res partner bank</field>
       <field name="model">res.partner.bank</field>
-      <field name="type">form</field>
       <field name="inherit_id" ref="base.view_partner_bank_form"/>
       <field name="arch" type="xml">
         <field name="bank_bic" position="after">

--- a/l10n_ch_base_bank/bank_view.xml
+++ b/l10n_ch_base_bank/bank_view.xml
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
   <data>
-    <record model="ir.ui.view" id="invoice_supplier_form6">
-      <field name="name">account.invoice.supplier.form.inherit</field>
-      <field name="model">account.invoice</field>
-      <field name="type">form</field>
-      <field name="inherit_id" ref="account.invoice_supplier_form"/>
-      <field name="arch" type="xml">
-        <field name="partner_id" position="replace">
-          <field name="partner_id" select="1"/>
-        </field>
-      </field>
-    </record>
-
     <record model="ir.ui.view" id="invoice_supplier_form8">
       <field name="name">account.invoice.supplier.form.inherit</field>
       <field name="model">account.invoice</field>

--- a/l10n_ch_base_bank/bank_view.xml
+++ b/l10n_ch_base_bank/bank_view.xml
@@ -8,8 +8,8 @@
       <field name="inherit_id" ref="account.invoice_supplier_form"/>
       <field name="priority" eval="18"/>
       <field name="arch" type="xml">
-        <field name="partner_bank_id" position="replace">
-          <field name="partner_bank_id" domain="[('partner_id', '=', partner_id)]"/>
+        <field name="partner_bank_id" position="attributes">
+          <attribute name="domain">[('partner_id', '=', partner_id)]</attribute>
         </field>
       </field>
     </record>
@@ -20,9 +20,8 @@
       <field name="type">form</field>
       <field name="inherit_id" ref="account.invoice_form"/>
       <field name="arch" type="xml">
-        <field name="partner_bank_id" position="replace">
-          <field name="partner_bank_id"
-                 domain="[('partner_id.ref_companies', 'in', [company_id])]"/>
+        <field name="partner_bank_id" position="attributes">
+          <attribute name="domain">[('partner_id.ref_companies', 'in', [company_id])]</attribute>
         </field>
       </field>
     </record>

--- a/l10n_ch_base_bank/invoice.py
+++ b/l10n_ch_base_bank/invoice.py
@@ -53,15 +53,19 @@ class AccountInvoice(models.Model):
             res['value']['partner_bank_id'] = bank_id
         return res
 
-    @api.onchange('partner_bank_id')
-    def onchange_partner_bank(self):
+    @api.multi
+    def onchange_partner_bank(self, partner_bank_id=False):
         """update the reference invoice_type depending of the partner bank"""
-        partner_bank = self.partner_bank_id
-        if partner_bank:
+        result = super(AccountInvoice, self).onchange_partner_bank(
+            partner_bank_id=partner_bank_id
+        )
+        if partner_bank_id:
+            partner_bank = self.env['res.partner.bank'].browse(partner_bank_id)
             if partner_bank.state == 'bvr':
-                self.reference_type = 'bvr'
+                result['value']['reference_type'] = 'bvr'
             else:
-                self.reference_type = 'none'
+                result['value']['reference_type'] = 'none'
+        return result
 
     @api.constrains('reference_type')
     def _check_reference_type(self):


### PR DESCRIPTION
- Remove the useless view that breaks the onchange
- Use 'attributes' instead of 'replace' and change only the domain
- Remove the deprecated 'type' of views
