### PR TITLE
[FIX] fields.Datetime to_string function is not compatible with DTA file...

### DIFF
--- a/l10n_ch_dta/wizard/create_dta.py
+++ b/l10n_ch_dta/wizard/create_dta.py
@@ -21,6 +21,7 @@
 #
 ##############################################################################
 import time
+from datetime import datetime
 import re
 import base64
 
@@ -676,7 +677,7 @@ class DTAFileGenerator(models.TransientModel):
         elif pline.date:
             date_value = fields.Date.from_string(pline.date)
         else:
-            date_value = fields.Date.from_string(fields.Datetime.now())
+            date_value = datetime.now().today()
         elec_context['date_value'] = date_value.strftime("%y%m%d")
         return elec_context
 

--- a/l10n_ch_dta/wizard/create_dta.py
+++ b/l10n_ch_dta/wizard/create_dta.py
@@ -20,7 +20,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from datetime import datetime
 import time
 import re
 import base64
@@ -673,13 +672,11 @@ class DTAFileGenerator(models.TransientModel):
         self._set_bank_data(pline, elec_context, seq)
 
         if pline.order_id.date_scheduled:
-            date_value = datetime.strptime(pline.order_id.date_scheduled,
-                                           '%Y-%m-%d')
+            date_value = fields.Date.from_string(pline.order_id.date_scheduled)
         elif pline.date:
-            date_value = datetime.strptime(pline.date,
-                                           '%Y-%m-%d')
+            date_value = fields.Date.from_string(pline.date)
         else:
-            date_value = datetime.now()
+            date_value = fields.Date.from_string(fields.Datetime.now())
         elec_context['date_value'] = date_value.strftime("%y%m%d")
         return elec_context
 

--- a/l10n_ch_dta/wizard/create_dta.py
+++ b/l10n_ch_dta/wizard/create_dta.py
@@ -20,6 +20,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
+from datetime import datetime
 import time
 import re
 import base64
@@ -547,7 +548,7 @@ class DTAFileGenerator(models.TransientModel):
         payment_obj = self.env['payment.order']
         payment = payment_obj.browse(data['id'])
         elec_context['uid'] = str(self.env.uid)
-        elec_context['creation_date'] = fields.Date.today()
+        elec_context['creation_date'] = time.strftime('%y%m%d')
         if not payment.mode:
             raise except_orm(
                 _('Error'),
@@ -671,15 +672,15 @@ class DTAFileGenerator(models.TransientModel):
             elec_context['partner_bvr'] = part
         self._set_bank_data(pline, elec_context, seq)
 
-        dt = fields.Datetime
-        date_to_datetime = lambda date: dt.to_string(dt.from_string(date))
         if pline.order_id.date_scheduled:
-            date_value = date_to_datetime(pline.order_id.date_scheduled)
+            date_value = datetime.strptime(pline.order_id.date_scheduled,
+                                           '%Y-%m-%d')
         elif pline.date:
-            date_value = date_to_datetime(pline.date)
+            date_value = datetime.strptime(pline.date,
+                                           '%Y-%m-%d')
         else:
-            date_value = fields.Datetime.now()
-        elec_context['date_value'] = date_value
+            date_value = datetime.now()
+        elec_context['date_value'] = date_value.strftime("%y%m%d")
         return elec_context
 
     @api.model


### PR DESCRIPTION
The DTA file generated contain date like 2015-0 (the date is limit to 6 characters in DTA file) instead of 150113 , so the bank refused the file due to wrong formated date, so I do not used the new v8 api to get the date in the right format.
Linked issue : #78 
