### PR TITLE
[account_statement_import] Move attachements from statement to statement_line

### DIFF
--- a/l10n_ch_account_statement_base_import/__openerp__.py
+++ b/l10n_ch_account_statement_base_import/__openerp__.py
@@ -45,7 +45,7 @@
  Warning : this module requires the python library 'xlrd'.
  """,
  'website': 'http://www.compassion.ch/',
- 'data': [],
+ 'data': ['view/statement_view.xml'],
  'test': [],
  'installable': True,
  'images': [],

--- a/l10n_ch_account_statement_base_import/statement.py
+++ b/l10n_ch_account_statement_base_import/statement.py
@@ -134,7 +134,7 @@ class AccountStatementLine(orm.Model):
             if name == 'file_name':
                 attachment = attachment_obj.browse(cr, uid, attachment_ids[0],
                                                    context)
-                res[st_line.id] = attachment.name
+                res[st_line.id] = _('View file')
             elif name == 'ir_attachment':
                 res[st_line.id] = attachment_ids[0]
         return res
@@ -149,6 +149,9 @@ class AccountStatementLine(orm.Model):
 
     def download_attachment(self, cr, uid, ids, context=None):
         st_line = self.browse(cr, uid, ids[0], context)
+        view_id = self.pool.get('ir.model.data').get_object_reference(
+            cr, uid, 'l10n_ch_account_statement_base_import',
+            'attachement_form_postfinance')[1]
         if st_line.ir_attachment:
             return {
                 'type': 'ir.actions.act_window',
@@ -156,7 +159,8 @@ class AccountStatementLine(orm.Model):
                 'view_type': 'form',
                 'view_mode': 'form',
                 'res_model': 'ir.attachment',
+                'view_id': view_id,
                 'res_id': st_line.ir_attachment.id,
-                'target': 'current',
+                'target': 'new',
             }
         return True

--- a/l10n_ch_account_statement_base_import/statement.py
+++ b/l10n_ch_account_statement_base_import/statement.py
@@ -100,7 +100,7 @@ class AccountStatementProfil(orm.Model):
                     if st_line.ref == filename[:-4]:
                         res_model = 'account.bank.statement.line'
                         res_id = st_line.id
-                        break;
+                        break
 
                 attachment_data = {
                     'name': filename,
@@ -132,8 +132,6 @@ class AccountStatementLine(orm.Model):
                 continue
 
             if name == 'file_name':
-                attachment = attachment_obj.browse(cr, uid, attachment_ids[0],
-                                                   context)
                 res[st_line.id] = _('View file')
             elif name == 'ir_attachment':
                 res[st_line.id] = attachment_ids[0]

--- a/l10n_ch_account_statement_base_import/tests/test_base_import.py
+++ b/l10n_ch_account_statement_base_import/tests/test_base_import.py
@@ -39,7 +39,7 @@ class l10n_ch_import(common.TransactionCase):
         self.profile_obj = self.registry("account.statement.profile")
         self.account_bank_statement_obj = self.registry(
             "account.bank.statement")
-        # create the 2002, 2011-2012 fiscal years since imported
+        # create the 2002, 2011-2012, 2014 fiscal years since imported
         # test files reference statement lines in those years
         self.fiscalyear_id = self._create_fiscalyear(
             "2002", self.company_a.id)
@@ -47,6 +47,8 @@ class l10n_ch_import(common.TransactionCase):
             "2011", self.company_a.id)
         self.fiscalyear_id = self._create_fiscalyear(
             "2012", self.company_a.id)
+        self.fiscalyear_id = self._create_fiscalyear(
+            "2014", self.company_a.id)
         self.account_id = self.ref("account.a_recv")
         self.journal_id = self.ref("account.bank_journal")
         self.import_wizard_obj = self.registry('credit.statement.import')

--- a/l10n_ch_account_statement_base_import/view/statement_view.xml
+++ b/l10n_ch_account_statement_base_import/view/statement_view.xml
@@ -16,5 +16,18 @@
              </data>
          </field>
      </record>
+     
+     <!-- Define a view on ir.attachment to see the attached picture -->
+     <record id="attachement_form_postfinance" model="ir.ui.view">
+        <field name="name">l10n_ch_bank_attachment.view_form</field>
+         <field name="model">ir.attachment</field>
+         <field eval="20" name="priority"/>
+         <field name="type">form</field>
+         <field name="arch" type="xml">
+            <form string="Attachments" version="7.0">
+                <field name="datas" widget="image" readonly="1"/>
+            </form>
+         </field>
+     </record>
 </data>
 </openerp>

--- a/l10n_ch_account_statement_base_import/view/statement_view.xml
+++ b/l10n_ch_account_statement_base_import/view/statement_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+    <record id="bank_statement_view_form_postfinance" model="ir.ui.view">
+         <field name="name">l10n_ch_bank_statement.view_form</field>
+         <field name="model">account.bank.statement</field>
+         <field name="inherit_id" ref="account_statement_base_completion.bank_statement_view_form2" />
+         <field eval="16" name="priority"/>
+         <field name="type">form</field>
+         <field name="arch" type="xml">
+             <data>
+                 <xpath expr="//tree/field[@name='already_completed']" position="after">
+                    <field name="file_name"/>
+                    <button name="download_attachment" type="object" icon="STOCK_SAVE" />
+                 </xpath>
+             </data>
+         </field>
+     </record>
+</data>
+</openerp>


### PR DESCRIPTION
In statement import module, the Postfinance parser was attaching pictures to the bank statement object. Those pictures are however corresponding to a specific statement line.

I propose to move the attachments directly to the statement line objects and added a button in the view in order to be able to display the attachment right from bank statement view.
