### PR TITLE
[7.0] Fix incorrect due_date for HEAD records in DD files.

### DIFF
--- a/l10n_ch_account_statement_base_import/tests/test_base_import.py
+++ b/l10n_ch_account_statement_base_import/tests/test_base_import.py
@@ -39,7 +39,7 @@ class l10n_ch_import(common.TransactionCase):
         self.profile_obj = self.registry("account.statement.profile")
         self.account_bank_statement_obj = self.registry(
             "account.bank.statement")
-        # create the 2002, 2011-2012 fiscal years since imported
+        # create the 2002, 2011-2012, 2014 fiscal years since imported
         # test files reference statement lines in those years
         self.fiscalyear_id = self._create_fiscalyear(
             "2002", self.company_a.id)
@@ -47,6 +47,8 @@ class l10n_ch_import(common.TransactionCase):
             "2011", self.company_a.id)
         self.fiscalyear_id = self._create_fiscalyear(
             "2012", self.company_a.id)
+        self.fiscalyear_id = self._create_fiscalyear(
+            "2014", self.company_a.id)
         self.account_id = self.ref("account.a_recv")
         self.journal_id = self.ref("account.bank_journal")
         self.import_wizard_obj = self.registry('credit.statement.import')

--- a/l10n_ch_lsv_dd/wizard/dd_export_wizard.py
+++ b/l10n_ch_lsv_dd/wizard/dd_export_wizard.py
@@ -139,21 +139,20 @@ class post_dd_export_wizard(orm.TransientModel):
                                     self._generate_total_record(
                                         properties, total_amount)))
                     total_amount = 0.0
-                    properties.update(
-                        {'dd_order_no': properties['dd_order_no'] + 1})
-                    properties.update({'trans_ser_no': 0})
-                    records.append(
-                        (None, self._generate_head_record(properties)))
-                    properties.update(
-                        {'trans_ser_no': properties['trans_ser_no'] + 1})
-                    previous_date = line.ml_maturity_date
                     due_date = self._get_treatment_date(
                         payment_order.date_prefered,
                         line.ml_maturity_date,
                         payment_order.date_scheduled,
                         line.name)
+                    properties.update({
+                        'dd_order_no': properties['dd_order_no'] + 1,
+                        'trans_ser_no': 0,
+                        'due_date': self._prepare_date(due_date)})
+                    records.append(
+                        (None, self._generate_head_record(properties)))
                     properties.update(
-                        {'due_date': self._prepare_date(due_date)})
+                        {'trans_ser_no': properties['trans_ser_no'] + 1})
+                    previous_date = line.ml_maturity_date
 
                 records.append((line, self._generate_debit_record(
                     line, properties, payment_order, cr, uid, context)))


### PR DESCRIPTION
Head records in Postfinance Direct Debit orders were wrong. The date was incorrectly set.
