### PR TITLE
Don't choose banks with no valid mandates for lsv/dd orders.

### DIFF
--- a/l10n_ch_lsv_dd/model/move_line.py
+++ b/l10n_ch_lsv_dd/model/move_line.py
@@ -55,13 +55,20 @@ class account_move_line(orm.Model):
                 for line in self.browse(cr, uid, ids, context=context):
                     line2bank[line.id] = False
                     if line.partner_id:
-                        for bank in line.partner_id.bank_ids:
-                            if bank.state in bank_type:
-                                for mandate in bank.mandate_ids:
-                                    if mandate.state == 'active':
-                                        line2bank[line.id] = bank.id
-                                        return line2bank
+                        bank_id = self._get_active_bank_account(
+                            cr, uid,
+                            line.partner_id.bank_ids,
+                            bank_type, context)
+                        line2bank[line.id] = bank_id
+                        if bank_id : return line2bank[line.id]
 
         res = super(account_move_line, self).line2bank(
             cr, uid, ids, payment_mode_id, context=None)
         return res
+
+    def _get_active_bank_account(self, cr, uid, banks, bank_type, context=None):
+        for bank in banks:
+            if bank.state in bank_type:
+                for mandate in bank.mandate_ids:
+                    if mandate.state == 'active':
+                        return bank.id

--- a/l10n_ch_lsv_dd/model/move_line.py
+++ b/l10n_ch_lsv_dd/model/move_line.py
@@ -50,7 +50,7 @@ class account_move_line(orm.Model):
                 cr, uid, payment_mode_id, context=context)
             if pay_mode.type.payment_order_type == 'debit':
                 line2bank = dict()
-                bank_type = pay_mode_obj.suitable_bank_types(
+                bank_types = pay_mode_obj.suitable_bank_types(
                     cr, uid, payment_mode_id, context=context)
                 for line in self.browse(cr, uid, ids, context=context):
                     line2bank[line.id] = False
@@ -58,7 +58,7 @@ class account_move_line(orm.Model):
                         bank_id = self._get_active_bank_account(
                             cr, uid,
                             line.partner_id.bank_ids,
-                            bank_type, context)
+                            bank_types, context)
                         line2bank[line.id] = bank_id
                         if bank_id:
                             return line2bank[line.id]
@@ -68,9 +68,9 @@ class account_move_line(orm.Model):
         return res
 
     def _get_active_bank_account(
-            self, cr, uid, banks, bank_type, context=None):
+            self, cr, uid, banks, bank_types, context=None):
         for bank in banks:
-            if bank.state in bank_type:
+            if bank.state in bank_types:
                 for mandate in bank.mandate_ids:
                     if mandate.state == 'active':
                         return bank.id

--- a/l10n_ch_lsv_dd/model/move_line.py
+++ b/l10n_ch_lsv_dd/model/move_line.py
@@ -65,11 +65,11 @@ class account_move_line(orm.Model):
                             line2bank.update(
                                 super(account_move_line, self).line2bank(
                                     cr, uid, [line.id],
-                                    payment_mode_id, context=None))
+                                    payment_mode_id, context=context))
                 return line2bank
         return super(
             account_move_line, self).line2bank(
-                cr, uid, ids, payment_mode_id, context=None)
+                cr, uid, ids, payment_mode_id, context=context)
 
     def _get_active_bank_account(
             self, cr, uid, banks, bank_types, context=None):

--- a/l10n_ch_lsv_dd/model/move_line.py
+++ b/l10n_ch_lsv_dd/model/move_line.py
@@ -76,5 +76,5 @@ class account_move_line(orm.Model):
         for bank in banks:
             if bank.state in bank_types:
                 for mandate in bank.mandate_ids:
-                    if mandate.state == 'active':
+                    if mandate.state == 'valid':
                         return bank.id

--- a/l10n_ch_lsv_dd/model/move_line.py
+++ b/l10n_ch_lsv_dd/model/move_line.py
@@ -60,13 +60,15 @@ class account_move_line(orm.Model):
                             line.partner_id.bank_ids,
                             bank_type, context)
                         line2bank[line.id] = bank_id
-                        if bank_id : return line2bank[line.id]
+                        if bank_id:
+                            return line2bank[line.id]
 
         res = super(account_move_line, self).line2bank(
             cr, uid, ids, payment_mode_id, context=None)
         return res
 
-    def _get_active_bank_account(self, cr, uid, banks, bank_type, context=None):
+    def _get_active_bank_account(
+            self, cr, uid, banks, bank_type, context=None):
         for bank in banks:
             if bank.state in bank_type:
                 for mandate in bank.mandate_ids:

--- a/l10n_ch_lsv_dd/model/move_line.py
+++ b/l10n_ch_lsv_dd/model/move_line.py
@@ -58,7 +58,7 @@ class account_move_line(orm.Model):
                         for bank in line.partner_id.bank_ids:
                             if bank.state in bank_type:
                                 for mandate in bank.mandate_ids:
-                                    if mandate.state != 'cancel':
+                                    if mandate.state == 'active':
                                         line2bank[line.id] = bank.id
                                         return line2bank
                         else:

--- a/l10n_ch_lsv_dd/model/move_line.py
+++ b/l10n_ch_lsv_dd/model/move_line.py
@@ -59,13 +59,17 @@ class account_move_line(orm.Model):
                             cr, uid,
                             line.partner_id.bank_ids,
                             bank_types, context)
-                        line2bank[line.id] = bank_id
                         if bank_id:
-                            return line2bank[line.id]
-
-        res = super(account_move_line, self).line2bank(
-            cr, uid, ids, payment_mode_id, context=None)
-        return res
+                            line2bank[line.id] = bank_id
+                        else:
+                            line2bank.update(
+                                super(account_move_line, self).line2bank(
+                                    cr, uid, [line.id],
+                                    payment_mode_id, context=None))
+                return line2bank
+        return super(
+            account_move_line, self).line2bank(
+                cr, uid, ids, payment_mode_id, context=None)
 
     def _get_active_bank_account(
             self, cr, uid, banks, bank_types, context=None):

--- a/l10n_ch_lsv_dd/model/move_line.py
+++ b/l10n_ch_lsv_dd/model/move_line.py
@@ -61,11 +61,8 @@ class account_move_line(orm.Model):
                                     if mandate.state == 'active':
                                         line2bank[line.id] = bank.id
                                         return line2bank
-                        else:
-                            res = super(account_move_line, self).line2bank(
-                                cr, uid, ids, payment_mode_id, context=None)
-                            return res
-        return super(account_move_line, self).line2bank(
-            cr, uid, ids,
-            payment_mode_id,
-            context=None)
+                        
+        res = super(account_move_line, self).line2bank(
+            cr, uid, ids, payment_mode_id, context=None)
+        return res
+        

--- a/l10n_ch_lsv_dd/model/move_line.py
+++ b/l10n_ch_lsv_dd/model/move_line.py
@@ -44,7 +44,7 @@ class account_move_line(orm.Model):
         ''' Override line2bank to avoid choosing a bank that has only
             cancelled mandate.
         '''
-        pay_mode_obj = self.pool.get['payment.mode']
+        pay_mode_obj = self.pool.get('payment.mode')
         if payment_mode_id:
             pay_mode = pay_mode_obj.browse(
                 cr, uid, payment_mode_id, context=context)
@@ -61,8 +61,7 @@ class account_move_line(orm.Model):
                                     if mandate.state == 'active':
                                         line2bank[line.id] = bank.id
                                         return line2bank
-                        
+
         res = super(account_move_line, self).line2bank(
             cr, uid, ids, payment_mode_id, context=None)
         return res
-        


### PR DESCRIPTION
Override line2bank to avoid choosing a bank that don't have valid mandates.
