### PR TITLE
Remove wrong usage of @api.v7

### DIFF
--- a/l10n_ch_credit_control_payment_slip_report/credit_control_communication_report.py
+++ b/l10n_ch_credit_control_payment_slip_report/credit_control_communication_report.py
@@ -17,7 +17,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from openerp import models, api
+from openerp import models
 
 
 class BVRFromCreditControl(models.AbstractModel):
@@ -29,7 +29,6 @@ class ExtendedReport(models.TransientModel):
 
     _inherit = "report"
 
-    @api.v7
     def get_pdf(self, cr, uid, ids, report_name, html=None, data=None,
                 context=None):
         if context is None:

--- a/l10n_ch_payment_slip/report/payment_slip_from_invoice.py
+++ b/l10n_ch_payment_slip/report/payment_slip_from_invoice.py
@@ -18,7 +18,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from openerp import api, models
+from openerp import models
 
 
 class BVRFromInvoice(models.AbstractModel):
@@ -29,7 +29,6 @@ class ExtendedReport(models.Model):
 
     _inherit = 'report'
 
-    @api.v7
     def _generate_one_slip_per_page_from_invoice_pdf(self, cr, uid, ids,
                                                      context=None):
         """Generate payment slip PDF(s) from report model.
@@ -57,7 +56,6 @@ class ExtendedReport(models.Model):
                 return self.merge_pdf_in_memory(docs)
             return self.merge_pdf_on_disk(docs)
 
-    @api.v7
     def get_pdf(self, cr, uid, ids, report_name, html=None, data=None,
                 context=None):
         if report_name == 'one_slip_per_page_from_invoice':


### PR DESCRIPTION
This decorator must only be used when @api.v8 is used in the same Model, it allows
to dispatch v8 and v7 calls to methods with the same name but with different signatures.

When used alone, if a v8 call is done to the method, it tries to call NoneType.
