### PR TITLE
[FIX] Prevent traceback when computing a bvr without reference

### DIFF
--- a/l10n_ch_payment_slip/invoice.py
+++ b/l10n_ch_payment_slip/invoice.py
@@ -86,7 +86,7 @@ class AccountInvoice(models.Model):
             return ''
         if not self.slip_ids:
             return ''
-        self.bvr_reference = ', '.join(x.reference for x in self.slip_ids)
+        self.bvr_reference = ', '.join(x.reference for x in self.slip_ids if x.reference)
 
     def get_payment_move_line(self):
         """Return the move line related to current invoice slips


### PR DESCRIPTION
When the bvr reference is False the _compute_full_bvr_name in invoice throws an error trying to join the False values
