### PR TITLE
Translate the payment slip in the customer's language

### DIFF
--- a/l10n_ch_payment_slip/payment_slip.py
+++ b/l10n_ch_payment_slip/payment_slip.py
@@ -669,6 +669,8 @@ class PaymentSlip(models.Model):
                 'Only PDF payment slip are supported'
             )
         self.ensure_one()
+        lang = self.invoice_id.partner_id.lang
+        self = self.with_context(lang=lang)
         company = self.env.user.company_id
         self._register_fonts()
         default_font = self._get_text_font()


### PR DESCRIPTION
The line "Payment slip related to invoice FA-1008-15 due on the 30-05-2015" is not translated in the customer's language but in the user's language.
Correct that by setting the customer's language in the context.

Fixes #130 
