### PR TITLE
Remove object field name from action definition

### DIFF
--- a/l10n_ch_sepa/wizard/wiz_pain_001_view.xml
+++ b/l10n_ch_sepa/wizard/wiz_pain_001_view.xml
@@ -44,7 +44,6 @@
             <field name="name">Create SEPA payment</field>
             <field name="value" eval="'ir.actions.act_window,%d'%action_create_pain_001" />
             <field name="key">action</field>
-            <field name="object" eval="1" />
         </record>
 
         <!-- TODO make available button depending on payment mode


### PR DESCRIPTION
This PR should fix a warning in runbot

```
2015-06-03 08:58:08     WARNING     server  openerp.models:4071 create ir.values.create() with unknown fields: object
```

Before:
https://runbot.odoo-community.org/runbot/build/2948178

After:
https://runbot.odoo-community.org/runbot/build/2948398
