### PR TITLE
[7.0-lsv-dd] fix : mandate_ids list must not contain duplicates

### DIFF
--- a/l10n_ch_lsv_dd/wizard/dd_export_wizard.py
+++ b/l10n_ch_lsv_dd/wizard/dd_export_wizard.py
@@ -296,7 +296,7 @@ class post_dd_export_wizard(orm.TransientModel):
             wf_service.trg_validate(uid, 'payment.order', order.id, 'done', cr)
             mandate_ids = [line.mandate_id.id for line in order.line_ids]
             self.pool['account.banking.mandate'].write(
-                cr, uid, mandate_ids, {
+                cr, uid, list(set(mandate_ids)), {
                     'last_debit_date': today_str}, context=context)
 
         # redirect to generated dd export

--- a/l10n_ch_lsv_dd/wizard/lsv_export_wizard.py
+++ b/l10n_ch_lsv_dd/wizard/lsv_export_wizard.py
@@ -281,7 +281,7 @@ class lsv_export_wizard(orm.TransientModel):
             wf_service.trg_validate(uid, 'payment.order', order.id, 'done', cr)
             mandate_ids = [line.mandate_id.id for line in order.line_ids]
             self.pool['account.banking.mandate'].write(
-                cr, uid, mandate_ids, {
+                cr, uid, list(set(mandate_ids)), {
                     'last_debit_date': today_str}, context=context)
 
         # redirect to generated lsv export


### PR DESCRIPTION
Bug fix where a list could contain twice or more the same ids causing the write method to raise an error.
