### PR TITLE
Allow to print BVR/ESR of multiple invoices (multiple pages)

### DIFF
--- a/l10n_ch_payment_slip/report/multi_bvr.mako
+++ b/l10n_ch_payment_slip/report/multi_bvr.mako
@@ -169,14 +169,20 @@
              top:${str(203 + (company.bvr_delta_vert or 0.0)).replace(',','.')}mm;
              left:${str(67 + (company.bvr_delta_horz or 0.0)).replace(',','.')}mm;
            }
-
-          ${css}
+          
+           div.page {
+             position: relative;
+             page-break-before: always;
+           }
+           
+           ${css}
     </style>
 
    </head>
    <body topmargin="0px">
 
        %for move in objects:
+       <div class="page">
        <% inv = move.invoice %>
        <% setLang(inv.partner_id.lang) %>
        <!--adresses + info block -->
@@ -301,6 +307,7 @@
             <div class="digitref"  style="left:${ref_start_left + (ii*ref_coef_space)}mm;">${c}</div>
         %endfor
  </div>
+    </div>
     %endfor
 </body>
 </html>

--- a/l10n_ch_payment_slip/report/multi_report_webkit_html.py
+++ b/l10n_ch_payment_slip/report/multi_report_webkit_html.py
@@ -76,14 +76,14 @@ class L10nCHReportWebkitHtmlMulti(report_sxw.rml_parse):
         move_line_obj = self.pool['account.move.line']
         account_obj = self.pool['account.account']
         invoice_obj = self.pool['account.invoice']
-        inv = invoice_obj.browse(cursor, uid, ids[0], context=context)
+        invoices = invoice_obj.browse(cursor, uid, ids, context=context)
         tier_account_ids = account_obj.search(
             cursor, uid,
             [('type', 'in', ['receivable', 'payable'])],
             context=context)
         move_line_ids = move_line_obj.search(
             cursor, uid,
-            [('move_id', '=', inv.move_id.id),
+            [('move_id', 'in', [inv.move_id.id for inv in invoices]),
              ('account_id', 'in', tier_account_ids)],
             context=context)
         return move_line_ids


### PR DESCRIPTION
Fix get_obj_reference of L10nCHReportWebkitHtmlMulti to return
the move ids for all selected invoices and add a page element
in mako css to manage page break properly.
