### PR TITLE
[FIX] when bank name is too long, it overlaps with 'giro' bank

### DIFF
--- a/l10n_ch_payment_slip/payment_slip.py
+++ b/l10n_ch_payment_slip/payment_slip.py
@@ -23,6 +23,7 @@ import base64
 import StringIO
 import contextlib
 import re
+import textwrap
 from collections import namedtuple
 from reportlab.pdfgen.canvas import Canvas
 from reportlab.pdfbase import pdfmetrics
@@ -547,7 +548,8 @@ class PaymentSlip(models.Model):
         text = canvas.beginText()
         text.setTextOrigin(x, y)
         text.setFont(font.name, font.size)
-        lines = bank.name.split("\n")
+        bank_name = textwrap.fill(bank.name, 26)
+        lines = bank_name.split("\n")
         text.textOut(lines.pop(0))
         text.moveCursor(0.0, font.size)
         for line in lines:


### PR DESCRIPTION
See example with 'Banca Raiffeisen del Cassarate':

![bvr](https://cloud.githubusercontent.com/assets/1033131/9270260/95bd7264-4270-11e5-8d48-188c9bd17e71.png)
