### PR TITLE
Print bank address instead company partner address

### DIFF
--- a/l10n_ch_payment_slip/bank.py
+++ b/l10n_ch_payment_slip/bank.py
@@ -17,7 +17,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from openerp import models, fields
+from openerp import models, fields, api
 
 
 class ResPartnerBank(models.Model):
@@ -33,3 +33,23 @@ class ResPartnerBank(models.Model):
     print_bank = fields.Boolean('Print Bank on BVR')
     print_account = fields.Boolean('Print Account Number on BVR')
     print_partner = fields.Boolean('Print Partner Address on BVR')
+
+    @api.multi
+    def _display_address(self):
+        """ Format bank address """
+        self.ensure_one()
+        address_format = (
+            self.country_id.address_format or
+            "%(company_name)s\n%(street)s\n%(city)s %(state_code)s"
+            " %(zip)s\n%(country_name)s")
+        args = {
+            'state_code': self.state_id.code or '',
+            'state_name': self.state_id.name or '',
+            'country_code': self.country_id.code or '',
+            'country_name': self.country_id.name or '',
+            'company_name': self.owner_name or '',
+            'street2': '',  # No such field on the this model
+        }
+        for field in ('street', 'zip', 'city', 'state_id', 'country_id'):
+            args[field] = getattr(self, field) or ''
+        return address_format % args

--- a/l10n_ch_payment_slip/payment_slip.py
+++ b/l10n_ch_payment_slip/payment_slip.py
@@ -486,6 +486,42 @@ class PaymentSlip(models.Model):
             text.textLine(line)
         canvas.drawText(text)
 
+    @api.model
+    def _draw_bank_address(
+            self, canvas, print_settings, initial_position, font, bank):
+        """Draw an bank address on canvas
+
+        :param canvas: payment slip reportlab component to be drawn
+        :type canvas: :py:class:`reportlab.pdfgen.canvas.Canvas`
+
+        :param print_settings: layouts print setting
+        :type print_settings: :py:class:`PaymentSlipSettings` or subclass
+
+        :para initial_position: tuple of coordinate (x, y)
+        :type initial_position: tuple
+
+        :param font: font to use
+        :type font: :py:class:`FontMeta`
+
+        :param bank: partner bank record for model `res.partner.bank`
+        :type bank: :py:class:`openerp.models.Model`
+
+        """
+        x, y = initial_position
+        x += print_settings.bvr_add_horz * inch
+        y += print_settings.bvr_add_vert * inch
+        text = canvas.beginText()
+        text.setTextOrigin(x, y)
+        text.setFont(font.name, font.size)
+        if bank.owner_name:
+            text.textOut(bank.owner_name)
+        text.moveCursor(0.0, font.size)
+        for line in bank._display_address().split("\n"):
+            if not line:
+                continue
+            text.textLine(line)
+        canvas.drawText(text)
+
     @api.multi
     def _draw_description_line(self, canvas, print_settings, initial_position,
                                font):
@@ -789,15 +825,17 @@ class PaymentSlip(models.Model):
                     initial_position = (0.05 * inch,  3.30 * inch)
                 else:
                     initial_position = (0.05 * inch,  3.75 * inch)
-                self._draw_address(canvas, print_settings, initial_position,
-                                   default_font, company.partner_id)
+                self._draw_bank_address(
+                    canvas, print_settings, initial_position, default_font,
+                    invoice.partner_bank_id)
                 if (invoice.partner_bank_id.print_account or
                         invoice.partner_bank_id.bvr_adherent_num):
                     initial_position = (2.45 * inch, 3.30 * inch)
                 else:
                     initial_position = (2.45 * inch, 3.75 * inch)
-                self._draw_address(canvas, print_settings, initial_position,
-                                   default_font, company.partner_id)
+                self._draw_bank_address(
+                    canvas, print_settings, initial_position, default_font,
+                    invoice.partner_bank_id)
             com_partner = self.get_comm_partner()
             initial_position = (0.05 * inch, 1.4 * inch)
             self._draw_address(canvas, print_settings, initial_position,


### PR DESCRIPTION
We've faced that company address can be different from bank account, so here is suggestion
to use res.partner.bank address instead company partners
e.g. Company is based in Belgium, but bank account is from Switzerland
