### PR TITLE
Missing security group in partner view of l10n_ch_scan_bvr added

### DIFF
--- a/l10n_ch_scan_bvr/views/partner_view.xml
+++ b/l10n_ch_scan_bvr/views/partner_view.xml
@@ -6,7 +6,7 @@
       <field name="model">res.partner</field>
       <field name="inherit_id" ref="base.view_partner_form" />
       <field name="type">form</field>
-      <field name=groups_id" eval="[(4, ref('account.group_account_invoice'))]" />
+      <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]" />
       <field name="arch" type="xml">
         <field name="credit_limit" position="after">
           <field name="supplier_invoice_default_product"/>

--- a/l10n_ch_scan_bvr/views/partner_view.xml
+++ b/l10n_ch_scan_bvr/views/partner_view.xml
@@ -6,6 +6,7 @@
       <field name="model">res.partner</field>
       <field name="inherit_id" ref="base.view_partner_form" />
       <field name="type">form</field>
+      <field name=groups_id" eval="[(4, ref('account.group_account_invoice'))]" />
       <field name="arch" type="xml">
         <field name="credit_limit" position="after">
           <field name="supplier_invoice_default_product"/>


### PR DESCRIPTION
Missing security group in partner view of l10n_ch_scan_bvr added
Otherwise users without this right can't access contacts.
