### PR TITLE
Remove leading space in BVR string

### DIFF
--- a/l10n_ch_scan_bvr/wizard/scan_bvr.py
+++ b/l10n_ch_scan_bvr/wizard/scan_bvr.py
@@ -266,8 +266,11 @@ class ScanBvr(models.TransientModel):
 
     def _get_bvr_structurated(self, bvr_string):
         if bvr_string is not False:
+            # Get rid of leading and ending spaces of the BVR string
+            bvr_string = bvr_string.strip()
+            
             # We will get the 2 first digits of the BVR string in order
-            # to now the BVR type of this account
+            # to know the BVR type of this account
             bvr_type = bvr_string[0:2]
             bvr_struct = {}
             if bvr_type == '01' and len(bvr_string) == 42:


### PR DESCRIPTION
This fix removes the leading space in BVR string. This space can cause
compatibility issues with some BVR scanners.
