### PR TITLE
Fix TypeError: _set_bank_data() takes at least 7 arguments (7 given)

### DIFF
--- a/l10n_ch_dta_base_transaction_id/wizard/create_dta.py
+++ b/l10n_ch_dta_base_transaction_id/wizard/create_dta.py
@@ -25,10 +25,10 @@ from openerp.osv import orm
 class DTAFileGenerator(orm.TransientModel):
     _inherit = "create.dta.wizard"
 
-    def _set_bank_data(self, cr, uid, data, pline, elec_context,
+    def _set_bank_data(self, cr, uid, pline, elec_context,
                        seq, context=None):
         super(DTAFileGenerator, self).\
-            _set_bank_data(cr, uid, data, pline,
+            _set_bank_data(cr, uid, pline,
                            elec_context, seq, context=context)
         if pline.move_line_id.transaction_ref:
             elec_context['reference'] = pline.move_line_id.transaction_ref


### PR DESCRIPTION
When the module is installed, the DTA creation raises the following error:

```
Fix TypeError: _set_bank_data() takes at least 7 arguments (7 given)
```
