### PR TITLE
[FIX] l10n_ch_scan_bvr: bvr_postal_in_chf with len 42

### DIFF
--- a/l10n_ch_scan_bvr/wizard/scan_bvr.py
+++ b/l10n_ch_scan_bvr/wizard/scan_bvr.py
@@ -116,7 +116,7 @@ class ScanBvr(models.TransientModel):
                 'type': bvr_string[0:2],
                 'amount': float(bvr_string[2:12]) / 100,
                 'reference': bvr_string[14:30],
-                'bvrnumber': '',
+                'bvrnumber': '000000',
                 'beneficiaire': self._create_bvr_account(bvr_string[32:41]),
                 'domain': '',
                 'currency': ''

--- a/l10n_ch_scan_bvr/wizard/scan_bvr.py
+++ b/l10n_ch_scan_bvr/wizard/scan_bvr.py
@@ -268,7 +268,7 @@ class ScanBvr(models.TransientModel):
         if bvr_string is not False:
             # Get rid of leading and ending spaces of the BVR string
             bvr_string = bvr_string.strip()
-            
+
             # We will get the 2 first digits of the BVR string in order
             # to know the BVR type of this account
             bvr_type = bvr_string[0:2]


### PR DESCRIPTION
Using  `0100021168001>0201671100001324+ 010850164>` as BVR string I get:

```
(Pdb) bvr_struct
{'domain': 'name', 'reference': u'0201671100001324', 'bvrnumber': '', 'currency': 'CHF', 'amount': 21168.0, 'beneficiaire': u'01-85016-4', 'type': u'01'}
```

and this implies a wrong domain here: https://github.com/OCA/l10n-switzerland/blob/8.0/l10n_ch_scan_bvr/wizard/scan_bvr.py#L351 
Indeed, partners_bank should be searched for **acc_number** and not for **bvr_adherent_num**
