### PR TITLE
Fix import in unit tests

### DIFF
--- a/l10n_ch_account_statement_base_import/tests/test_base_swiss_importer.py
+++ b/l10n_ch_account_statement_base_import/tests/test_base_swiss_importer.py
@@ -19,11 +19,11 @@
 #
 ##############################################################################
 from openerp.tests import common
-from ..parser.postfinance_file_parser import XMLPFParser
-from ..parser.g11_file_parser import G11Parser
-from ..parser.raiffeisen_file_parser import RaffeisenCSVParser
-from ..parser.ubs_file_parser import UBSCSVParser
-from ..parser.v11_file_parser import V11Parser
+from ..parsers.postfinance_file_parser import XMLPFParser
+from ..parsers.g11_file_parser import G11Parser
+from ..parsers.raiffeisen_file_parser import RaffeisenCSVParser
+from ..parsers.ubs_file_parser import UBSCSVParser
+from ..parsers.v11_file_parser import V11Parser
 
 
 class BaseSwissImporterTest(common.TransactionCase):

--- a/l10n_ch_account_statement_base_import/tests/test_g11.py
+++ b/l10n_ch_account_statement_base_import/tests/test_g11.py
@@ -19,7 +19,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from ..parser.g11_file_parser import G11Parser
+from ..parsers.g11_file_parser import G11Parser
 from .common import BaseParserTest, BaseStatementImportTest
 
 

--- a/l10n_ch_account_statement_base_import/tests/test_postfinance_xml.py
+++ b/l10n_ch_account_statement_base_import/tests/test_postfinance_xml.py
@@ -19,7 +19,7 @@
 #
 ##############################################################################
 import re
-from ..parser.postfinance_file_parser import XMLPFParser
+from ..parsers.postfinance_file_parser import XMLPFParser
 from .common import BaseParserTest, BaseStatementImportTest
 
 

--- a/l10n_ch_account_statement_base_import/tests/test_raiffeisen.py
+++ b/l10n_ch_account_statement_base_import/tests/test_raiffeisen.py
@@ -18,7 +18,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from ..parser.raiffeisen_file_parser import RaffeisenCSVParser
+from ..parsers.raiffeisen_file_parser import RaffeisenCSVParser
 from .common import BaseParserTest, BaseStatementImportTest
 
 

--- a/l10n_ch_account_statement_base_import/tests/test_ubs.py
+++ b/l10n_ch_account_statement_base_import/tests/test_ubs.py
@@ -19,7 +19,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from ..parser.ubs_file_parser import UBSCSVParser
+from ..parsers.ubs_file_parser import UBSCSVParser
 from .common import BaseParserTest, BaseStatementImportTest
 
 

--- a/l10n_ch_account_statement_base_import/tests/test_v11.py
+++ b/l10n_ch_account_statement_base_import/tests/test_v11.py
@@ -18,7 +18,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from ..parser.v11_file_parser import V11Parser
+from ..parsers.v11_file_parser import V11Parser
 from .common import BaseParserTest, BaseStatementImportTest
 
 


### PR DESCRIPTION
Fixes this error as directories where renamed:

https://travis-ci.org/OCA/l10n-switzerland/jobs/122950643

```
2016-04-14 05:25:02,605 23868 ERROR openerp_test openerp.modules.module: Can not `import l10n_ch_account_statement_base_import`.
Traceback (most recent call last):
File "/home/travis/odoo-8.0/openerp/modules/module.py", line 377, in get_test_modules
mod = importlib.import_module('.tests', modpath)
File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
__import__(name)
File "/home/travis/build/OCA/l10n-switzerland/l10n_ch_account_statement_base_import/tests/__init__.py", line 21, in <module>
from . import test_base_swiss_importer
File "/home/travis/build/OCA/l10n-switzerland/l10n_ch_account_statement_base_import/tests/test_base_swiss_importer.py", line 22, in <module>
from ..parser.postfinance_file_parser import XMLPFParser
ImportError: No module named parser.postfinance_file_parser
```
