### PR TITLE
Fix test by separating l10n_ch_lsv_dd as it pulls account_banking_pay…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,10 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo"
-  - TESTS="1" ODOO_REPO="OCA/OCB"
+  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="l10n_ch_lsv_dd,l10n_ch_fds_upload_dd"
+  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="l10n_ch_lsv_dd,l10n_ch_fds_upload_dd"
+  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="l10n_ch_lsv_dd,l10n_ch_fds_upload_dd"
+  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="l10n_ch_lsv_dd,l10n_ch_fds_upload_dd"
 
 virtualenv:
   system_site_packages: true


### PR DESCRIPTION
…ment_export which adds a required type field on payment.mode

The required field is added here:

https://github.com/OCA/bank-payment/blob/bafffd0eded6a7eb71570d3f22bfb91dc19ba4bc/account_banking_payment_export/models/payment_mode.py#L70-L71

```
l10n_ch_lsv_dd
└── account_banking_mandate
    └── account_banking_payment_export
```
