### PR TITLE
[8.0] l10n_ch_scan_bvr - Fix test by following change of affa1943d6f23b93cbd6e5b4e52e7beb5e1e978d

### DIFF
--- a/l10n_ch_scan_bvr/tests/test_scan_bvr.py
+++ b/l10n_ch_scan_bvr/tests/test_scan_bvr.py
@@ -82,7 +82,6 @@ class TestScanBvr(common.TransactionCase):
         })
         act = wizard.validate_bvr_string()
         self.assertTrue(act['res_id'])
-        self.assertTrue(self.partner1bank1.bvr_adherent_num)
 
         new_invoice = self.env['account.invoice'].browse(act['res_id'])
         self.assertAlmostEqual(3949.75, new_invoice.amount_total, places=2)


### PR DESCRIPTION
`bvr_adherent_number` is not set anymore, this was changed in:

https://github.com/OCA/l10n-switzerland/commit/affa1943d6f23b93cbd6e5b4e52e7beb5e1e978d
