### PR TITLE
[8.0] l10n_ch_payment_slip - Change test data bic to match check of account_banking_payment_export…

### DIFF
--- a/l10n_ch_payment_slip/tests/test_payment_slip.py
+++ b/l10n_ch_payment_slip/tests/test_payment_slip.py
@@ -37,7 +37,7 @@ class TestPaymentSlip(test_common.TransactionCase):
             {
                 'name': 'BCV',
                 'ccp': '01-1234-1',
-                'bic': '234234',
+                'bic': '23452345',
                 'clearing': '234234',
             }
         )


### PR DESCRIPTION
… module

This intend to fix l10n_ch_lsv_dd,l10n_ch_fds_upload_dd tests

Other tests are fixed in #235 
