### PR TITLE
[8.0] l10n_ch_scan_bvr - fix payment term

### DIFF
--- a/l10n_ch_scan_bvr/wizard/scan_bvr.py
+++ b/l10n_ch_scan_bvr/wizard/scan_bvr.py
@@ -212,7 +212,8 @@ class ScanBvr(models.TransientModel):
                  'ccp': data['bvr_struct']['beneficiaire']})
         date_due = today
         # We will now compute the due date and fixe the payment term
-        payment_term_id = account_info.partner_id.property_payment_term.id
+        payment_term_id = (account_info.partner_id.
+                           property_supplier_payment_term.id)
         if payment_term_id:
             # We Calculate due_date
             res = invoice_model.onchange_payment_term_date_invoice(


### PR DESCRIPTION
When creating the invoice from esr scan the customer payment term is used instead of supplier payment term
