### PR TITLE
Add index on invoice_id for account.move.line

### DIFF
--- a/l10n_ch_payment_slip/models/invoice.py
+++ b/l10n_ch_payment_slip/models/invoice.py
@@ -13,6 +13,15 @@ class AccountMoveLine(models.Model):
                                        string='Payment Slips',
                                        readonly=True)
 
+    # Adding an index on invoice_id for the account.move.line.
+    # The goal is to optimize the related field on payment_slip,
+    # as updating the stored value will trigger a:
+    #     self.env['account.move.line'].search([('invoice_id', '=', [xxx])])
+    # for each invoice validation.
+    invoice_id = fields.Many2one(
+        'account.invoice', oldname="invoice", index=True
+    )
+
 
 class AccountInvoice(models.Model):
     """Inherit account.invoice in order to add bvr


### PR DESCRIPTION
This PR is to correct a performance issue I noticed with a customer with millions of move lines.

Basically, since the `payment.slip` object has a related field `invoice_id` defined as `move_line_id.invoice_id` , validating an invoice will launch a search for payment slips with that invoice ID, which then launches another search for move lines with this invoice ID.

However, the default `invoice_id` in the move line does not have an index ; this means that a large part of the invoice's validation is spent searching for those move lines. With an index on this field, it's almost instantaneous.
