### PR TITLE
fix wrong payment term (customer instead of supplier based)

### DIFF
--- a/l10n_ch_scan_bvr/wizard/scan_bvr.py
+++ b/l10n_ch_scan_bvr/wizard/scan_bvr.py
@@ -202,7 +202,7 @@ class ScanBvr(models.TransientModel):
             [('name', '=', data['bvr_struct']['currency'])])
         date_due = today
         # We will now compute the due date and fixe the payment term
-        payment_term_id = account_info.partner_id.property_payment_term.id
+        payment_term_id = account_info.partner_id.property_supplier_payment_term.id
         if payment_term_id:
             # We Calculate due_date
             res = invoice_model.onchange_payment_term_date_invoice(


### PR DESCRIPTION
When creating the invoice from esr scan the customer payment term is used instead of supplier payment term
