### PR TITLE
Fix a misusage of v7 api in payment slip

### DIFF
--- a/l10n_ch_payment_slip/report/payment_slip_from_invoice.py
+++ b/l10n_ch_payment_slip/report/payment_slip_from_invoice.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # © 2014-2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from openerp import models
+from openerp import api, models
 
 
 class BVRFromInvoice(models.AbstractModel):
@@ -46,6 +46,7 @@ class ExtendedReport(models.Model):
                 return self.merge_pdf_in_memory(pdfs)
             return self.merge_pdf_on_disk(pdfs)
 
+    @api.v7
     def get_pdf(self, cr, uid, ids, report_name, html=None, data=None,
                 context=None):
         if (report_name == 'l10n_ch_payment_slip.'
@@ -67,3 +68,10 @@ class ExtendedReport(models.Model):
                 data=data,
                 context=context
             )
+
+    @api.v8  # noqa
+    def get_pdf(self, records, report_name, html=None, data=None):
+        return ExtendedReport.get_pdf(
+            self._model, self._cr, self._uid, records.ids,
+            report_name, html=html, data=data, context=self._context
+        )


### PR DESCRIPTION
Without @api.v7, the method receive arguments from v8 callers with a
shift. We also need to specify the v8 version as both should be in the
same file.
