### PR TITLE
[9.0] l10n_ch_bank - Fix ccp computation from IBAN of postal account by normalizing it

### DIFF
--- a/l10n_ch_base_bank/__openerp__.py
+++ b/l10n_ch_base_bank/__openerp__.py
@@ -4,7 +4,7 @@
 
 {'name': 'Switzerland - Bank type',
  'summary': 'Types and number validation for swiss electronic pmnt. DTA, ESR',
- 'version': '9.0.1.0.0',
+ 'version': '9.0.1.0.1',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'category': 'Localization',
  'website': 'http://www.camptocamp.com',

--- a/l10n_ch_base_bank/models/bank.py
+++ b/l10n_ch_base_bank/models/bank.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
-# © 2012 Nicolas Bessi (Camptocamp SA)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2012-2016 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import re
 from openerp import models, fields, api, _
 from openerp.tools import mod10r
 from openerp import exceptions
+
+from openerp.addons.base_iban import base_iban
 
 
 class BankCommon(object):
@@ -52,6 +54,7 @@ class BankCommon(object):
         """
         if not iban[:2] == 'CH':
             return False
+        iban = base_iban.normalize_iban(iban)
         part1 = iban[-9:-7]
         part2 = iban[-7:-1].lstrip('0')
         part3 = iban[-1:].lstrip('0')

--- a/l10n_ch_base_bank/tests/test_bank.py
+++ b/l10n_ch_base_bank/tests/test_bank.py
@@ -31,6 +31,16 @@ class TestBank(common.TransactionCase):
         self.assertEqual(bank_acc.ccp, '10-8060-7')
         self.assertEqual(bank_acc.acc_type, 'iban')
 
+    def test_iban_ccp_with_spaces(self):
+        bank_acc = self.env['res.partner.bank'].create({
+            'partner_id': self.partner.id,
+            'bank_id': self.post_bank.id,
+            'acc_number': 'CH09 0900 0000 1000 8060 7',
+            'bvr_adherent_num': '1234567',
+        })
+        self.assertEqual(bank_acc.ccp, '10-8060-7')
+        self.assertEqual(bank_acc.acc_type, 'iban')
+
     def test_faulty_ccp_at_bank(self):
         with self.assertRaises(exceptions.ValidationError):
             with mute_logger():


### PR DESCRIPTION
This allows to put IBAN with spaces separations for readability and visual check

ex CH09 0900 0000 1000 8060 7 becomes 10-8060-7