### PR TITLE
[ADD] requirements.txt: Add standard requirements and fix error of dependencies for runbot_travis2docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,6 @@ virtualenv:
   system_site_packages: true
 
 install:
-  - pip install -q unidecode
-  - pip install unicodecsv
-  - pip install xlrd
-  - pip install pysftp
-  - pip install wand
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+unidecode
+unicodecsv
+# Excel support
+xlrd
+pycrypto
+pysftp
+wand


### PR DESCRIPTION
Currently the new runbot based on runbot_travis2docker show the error:
`except_orm: ('Error', u'Unable to install module "l10n_ch_fds_postfinance" because an external dependency is not met: No module named Crypto')`

Travis don't show this error because the default image has installed this packages by default.
You can verify it with the following command:
 - `docker run -it --rm quay.io/travisci/travis-python /bin/bash -c "su - travis -c 'source ~/virtualenv/python2.7_with_system_site_packages/bin/activate && pip freeze'"`

```bash
bzr==2.5.1
configobj==4.7.2
GnuPGInterface==0.3.2
httplib2==0.7.2
keyring==0.9.2
launchpadlib==1.9.12
lazr.restfulclient==0.12.0
lazr.uri==1.0.3
mercurial==2.0.2
mock==1.0.1
nose==1.3.4
numpy==1.9.1
oauth==1.0.1
paramiko==1.7.7.1
py==1.4.26
pycrypto==2.4.1
pycurl==7.19.0
pytest==2.6.4
python-apt===0.8.3ubuntu7.2
simplejson==2.3.2
unattended-upgrades==0.1
virtualenv==12.0.6
wadllib==1.3.0
wheel==0.24.0
zope.interface==3.6.1
```

Notice that the travis default image have installed `pycrypto==2.4.1`

Then travis don't show the error.
Old runbot don't show this error because was installed manually.

This PR add this hidden dependency to requirements.txt