### PR TITLE
[9.0][Fix] Unique BVR reference type

### DIFF
--- a/l10n_ch_payment_slip/models/invoice.py
+++ b/l10n_ch_payment_slip/models/invoice.py
@@ -29,22 +29,7 @@ class AccountInvoice(models.Model):
 
     _inherit = "account.invoice"
 
-    @api.model
-    def _get_reference_type(self):
-        """Function used by the function field 'reference_type'
-        in order to initalise available BVR Reference Types
-        """
-        res = super(AccountInvoice, self)._get_reference_type()
-        res.append(('bvr', 'BVR'))
-        return res
-
     reference = fields.Char(copy=False)
-
-    reference_type = fields.Selection(
-        _get_reference_type,
-        string='Reference Type',
-        required=True
-    )
 
     partner_bank_id = fields.Many2one(
         'res.partner.bank',


### PR DESCRIPTION
As the reference type 'BVR Reference' is already added in l10n_ch_base_bank, and as l10n_ch_payment_slip depends on l10n_ch_base_bank, adding a 'BVR' reference_type here with the same 'bvr' key, makes it redundant.
