### PR TITLE
[8.0] FIX l10n_ch_payment_slip: when country is not present in 'Address Format' , do not remove part of the address.

### DIFF
--- a/l10n_ch_payment_slip/payment_slip.py
+++ b/l10n_ch_payment_slip/payment_slip.py
@@ -483,9 +483,6 @@ class PaymentSlip(models.Model):
         text.moveCursor(0.0, font.size)
 
         address_lines = com_partner.contact_address.split("\n")
-        if com_partner.country_id:
-            del address_lines[-1]
-
         for line in address_lines:
             if not line:
                 continue


### PR DESCRIPTION
To reproduce the problem: customer has country_id but country_id.address_format does not contain 'country_name' nor 'country_id'.
Printing payment slip, line '%(city)s %(state_code)s %(zip)s' is not diplayed.