### PR TITLE
[FIX] DTA - when paying to bank account with free reference

### DIFF
--- a/l10n_ch_dta/__openerp__.py
+++ b/l10n_ch_dta/__openerp__.py
@@ -21,7 +21,7 @@
 
 {'name': 'Switzerland - Bank Payment File (DTA)',
  'summary': 'Electronic payment file for Swiss bank (DTA)',
- 'version': '9.0.1.0.2',
+ 'version': '9.0.1.0.3',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'category': 'Localization',
  'website': 'http://www.camptocamp.com',


### PR DESCRIPTION
And you have setup bank account with iban + bank_id.ccp

When an iban and a ccp are set an the bank account we want to
use the iban for free references payments.

Currently we were passing a ccp as an iban given by get_account() method.