### PR TITLE
[9.0] l10n_ch_base_bank - Improve UX by defining onchange to set bank when account is entered

### DIFF
--- a/l10n_ch_base_bank/__openerp__.py
+++ b/l10n_ch_base_bank/__openerp__.py
@@ -4,7 +4,7 @@
 
 {'name': 'Switzerland - Bank type',
  'summary': 'Types and number validation for swiss electronic pmnt. DTA, ESR',
- 'version': '9.0.1.0.1',
+ 'version': '9.0.1.1.0',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'category': 'Localization',
  'website': 'http://www.camptocamp.com',

--- a/l10n_ch_base_bank/models/bank.py
+++ b/l10n_ch_base_bank/models/bank.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2016 Camptocamp
+# Copyright 2012-2017 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import re
 from openerp import models, fields, api, _
@@ -10,6 +10,10 @@ from openerp.addons.base_iban import base_iban
 
 
 class BankCommon(object):
+
+    def is_swiss_postal_num(self, number):
+        return (self._check_9_pos_postal_num(number) or
+                self._check_5_pos_postal_num(number))
 
     def _check_9_pos_postal_num(self, number):
         """
@@ -52,9 +56,9 @@ class BankCommon(object):
         """
         Convert a Postfinance IBAN into an old postal number
         """
-        if not iban[:2] == 'CH':
-            return False
         iban = base_iban.normalize_iban(iban)
+        if not iban[:2].upper() == 'CH':
+            return False
         part1 = iban[-9:-7]
         part2 = iban[-7:-1].lstrip('0')
         part3 = iban[-1:].lstrip('0')
@@ -62,6 +66,16 @@ class BankCommon(object):
         if not self._check_9_pos_postal_num(ccp):
             return False
         return ccp
+
+    def _convert_iban_to_clearing(self, iban):
+        """
+        Convert a Swiss Iban to a clearing
+        """
+        iban = base_iban.normalize_iban(iban)
+        if not iban[:2].upper() == 'CH':
+            return False
+        clearing = iban[4:9].lstrip('0')
+        return clearing
 
 
 class Bank(models.Model, BankCommon):
@@ -92,13 +106,16 @@ class Bank(models.Model, BankCommon):
         for bank in self:
             if not bank.ccp:
                 continue
-            if not (self._check_9_pos_postal_num(bank.ccp) or
-                    self._check_5_pos_postal_num(bank.ccp)):
+            if not self.is_swiss_postal_num(bank.ccp):
                 raise exceptions.ValidationError(
                     _('Please enter a correct postal number. '
                       '(01-23456-1 or 12345)')
                 )
         return True
+
+    @api.multi
+    def is_swiss_post(self):
+        return self.bic == 'POFICHBEXXX'
 
     @api.multi
     def name_get(self):
@@ -160,40 +177,18 @@ class ResPartnerBank(models.Model, BankCommon):
         string='Account/IBAN Number'
     )
     ccp = fields.Char(
-        compute="_compute_ccp",
         string='CCP/CP-Konto',
-        store=True,
-        readonly=True
+        store=True
     )
 
     @api.one
     @api.depends('acc_number')
     def _compute_acc_type(self):
         if (self.acc_number and
-                (self._check_9_pos_postal_num(self.acc_number) or
-                 self._check_5_pos_postal_num(self.acc_number))):
+                self.is_swiss_postal_num(self.acc_number)):
             self.acc_type = 'postal'
             return
         super(ResPartnerBank, self)._compute_acc_type()
-
-    @api.one
-    @api.depends('acc_type', 'bank_id.ccp')
-    def _compute_ccp(self):
-        """ Compute CCP
-        It can be:
-        - a postal account, we use acc_number
-        - a postal account in iban format, we transform acc_number
-        - a bank account with CCP on the bank, we use ccp of the bank
-        - otherwise there is no CCP to use
-        """
-        if self.acc_type == 'postal':
-            self.ccp = self.acc_number
-        elif self.acc_type == 'iban' and self.bank_id.bic == 'POFICHBEXXX':
-            self.ccp = self._convert_iban_to_ccp(self.acc_number.strip())
-        elif self.bank_id.ccp:
-            self.ccp = self.bank_id.ccp
-        else:
-            self.ccp = False
 
     @api.multi
     def get_account_number(self):
@@ -220,20 +215,139 @@ class ResPartnerBank(models.Model, BankCommon):
                 )
         return True
 
-    @api.onchange('acc_number', 'acc_type')
-    def onchange_set_swiss_post_bank(self):
-        """ If acc_number is set to a postal number try to find the bank
+    @api.constrains('ccp')
+    def _check_postal_num(self):
+        """Validate postal number format"""
+        for bank in self:
+            if not bank.ccp:
+                continue
+            if not self.is_swiss_postal_num(bank.ccp):
+                raise exceptions.ValidationError(
+                    _('Please enter a correct postal number. '
+                      '(01-23456-1 or 12345)')
+                )
+        return True
+
+    @api.multi
+    def _get_acc_name(self):
+        """ Return an account name for a bank account
+        to use with a ccp for BVR.
+        This method make sure to generate a unique name
         """
+        part_name = self.partner_id.name
+        if part_name:
+            acc_name = _("Bank/CCP {}").format(self.partner_id.name)
+        else:
+            acc_name = _("Bank/CCP Undefined")
+
+        exist_count = self.env['res.partner.bank'].search_count(
+            [('acc_number', '=like', acc_name)])
+        if exist_count:
+            name_exist = exist_count
+            while name_exist:
+                new_name = acc_name + " ({})".format(exist_count)
+                name_exist = self.env['res.partner.bank'].search_count(
+                    [('acc_number', '=', new_name)])
+                exist_count += 1
+            acc_name = new_name
+        return acc_name
+
+    @api.multi
+    def _get_ch_bank_from_iban(self):
+        """ Extract clearing number from iban to find the bank """
+        if self.acc_type != 'iban':
+            return False
+        clearing = self._convert_iban_to_clearing(self.acc_number)
+        return clearing and self.env['res.bank'].search(
+            [('clearing', '=', clearing)], limit=1)
+
+    @api.onchange('acc_number', 'acc_type')
+    def onchange_acc_number_set_swiss_bank(self):
+        """ Set the bank when possible
+        and set ccp when undefined
+        Bank is defined as:
+        - Found bank with CCP matching Bank CCP
+        - Swiss post when CCP is no matching a Bank CCP
+        - Found bank by clearing when using iban
+        For CCP it can be:
+        - a postal account, we copy acc_number
+        - a postal account in iban format, we transform acc_number
+        - a bank account with CCP on the bank, we use ccp of the bank
+        - otherwise there is no CCP to use
+        """
+        bank = self.bank_id
+        ccp = False
         if self.acc_type == 'postal':
-            post = self.env['res.bank'].search([('bic', '=', 'POFICHBEXXX')])
-            if post:
-                self.bank_id = post
+            ccp = self.acc_number
+            # Try to find a matching bank to the ccp entered in acc_number
+            # Overwrite existing bank if there is a match
+            bank = (
+                self.env['res.bank'].search([('ccp', '=', ccp)], limit=1) or
+                bank or
+                self.env['res.bank'].search([('bic', '=', 'POFICHBEXXX')],
+                                            limit=1))
+            if not bank.is_swiss_post():
+                self.acc_number = self._get_acc_name()
+        elif self.acc_type == 'iban':
+            if not bank:
+                bank = self._get_ch_bank_from_iban()
+            if bank:
+                if bank.is_swiss_post():
+                    ccp = self._convert_iban_to_ccp(self.acc_number.strip())
+                else:
+                    ccp = bank.ccp
+        elif self.bank_id.ccp:
+            ccp = self.bank_id.ccp
+        self.bank_id = bank
+        if not self.ccp:
+            self.ccp = ccp
+
+    @api.onchange('ccp')
+    def onchange_ccp_set_empty_acc_number(self):
+        """ If acc_number is empty and bank ccp is defined fill it """
+        if self.bank_id:
+            if not self.acc_number and self.ccp:
+                if self.bank_id.is_swiss_post():
+                    self.acc_number = self.ccp
+                else:
+                    self.acc_number = self._get_acc_name()
+            return
+
+        ccp = self.ccp
+        if ccp and self.is_swiss_postal_num(ccp):
+            bank = (
+                self.env['res.bank'].search([('ccp', '=', ccp)], limit=1) or
+                self.env['res.bank'].search([('bic', '=', 'POFICHBEXXX')],
+                                            limit=1))
+            if not self.acc_number:
+                if not bank.is_swiss_post():
+                    self.acc_number = self._get_acc_name()
+                else:
+                    self.acc_number = self.ccp
+            self.bank_id = bank
 
     @api.onchange('bank_id')
-    def onchange_bank(self):
+    def onchange_bank_set_acc_number(self):
         """ If acc_number is empty and bank ccp is defined fill it """
-        if not self.acc_number and self.bank_id.ccp:
-            self.acc_number = 'Bank/CCP ' + self.bank_id.ccp
+        if not self.bank_id:
+            return
+        if self.bank_id.is_swiss_post():
+            if not self.acc_number:
+                self.acc_number = self.ccp
+            elif not self.ccp and self.is_swiss_postal_num(self.acc_number):
+                self.ccp = self.acc_number
+        else:
+            if not self.acc_number and self.ccp:
+                self.acc_number = self._get_acc_name()
+            elif self.is_swiss_postal_num(self.acc_number):
+                self.ccp = self.acc_number
+                self.acc_number = self._get_acc_name()
+
+    @api.onchange('partner_id')
+    def onchange_partner_set_acc_number(self):
+        if self.acc_type == 'bank' and self.ccp:
+            if 'Bank/CCP' in self.acc_number:
+                self.acc_number = self._get_acc_name()
 
     _sql_constraints = [('bvr_adherent_uniq', 'unique (bvr_adherent_num)',
                          'The BVR adherent number must be unique !')]

--- a/l10n_ch_base_bank/models/invoice.py
+++ b/l10n_ch_base_bank/models/invoice.py
@@ -35,7 +35,7 @@ class AccountInvoice(models.Model):
                 bank_acc = invoice.partner_bank_id
                 if not (bank_acc.acc_type == 'postal' or
                         bank_acc.acc_type != 'postal' and
-                        bank_acc.bank_id.ccp):
+                        (bank_acc.ccp or bank_acc.bank_id.ccp)):
                     if invoice.type in ('in_invoice', 'in_refund'):
                         raise exceptions.ValidationError(
                             _('BVR/ESR Reference type needs a postal account'

--- a/l10n_ch_base_bank/tests/test_bank.py
+++ b/l10n_ch_base_bank/tests/test_bank.py
@@ -1,66 +1,209 @@
 # -*- coding: utf-8 -*-
-# © 2014-2015 Nicolas Bessi (Camptocamp SA)
-# © 2015 Yannick Vaucher (Camptocamp SA)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2014-2015 Nicolas Bessi (Camptocamp SA)
+# Copyright 2015-2017 Yannick Vaucher (Camptocamp SA)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from openerp.tests import common
 from openerp.tools import mute_logger
 from openerp import exceptions
 
+ch_iban = 'CH15 3881 5158 3845 3843 7'
+ch_post_iban = 'CH09 0900 0000 1000 8060 7'
+fr_iban = 'FR8387234133870990794002530'
+
 
 class TestBank(common.TransactionCase):
 
-    def test_ccp_at_bank(self):
-        self.bank.write({
-            'ccp': '01-1234-1',
-        })
+    def test_bank_iban(self):
         bank_acc = self.env['res.partner.bank'].create({
             'partner_id': self.partner.id,
-            'bank_id': self.bank.id,
-            'acc_number': 'R 12312123',
-            'bvr_adherent_num': '1234567',
+            'acc_number': ch_iban.replace(' ', ''),
         })
+        bank_acc.onchange_acc_number_set_swiss_bank()
+
+        self.assertEqual(bank_acc.bank_id, self.bank)
+        self.assertEqual(bank_acc.acc_number, ch_iban.replace(' ', ''))
+        self.assertEqual(bank_acc.ccp, '46-110-7')
+        self.assertEqual(bank_acc.acc_type, 'iban')
+
+    def test_bank_iban_with_spaces(self):
+        bank_acc = self.env['res.partner.bank'].create({
+            'partner_id': self.partner.id,
+            'acc_number': ch_iban,
+        })
+        bank_acc.onchange_acc_number_set_swiss_bank()
+
+        self.assertEqual(bank_acc.bank_id, self.bank)
+        self.assertEqual(bank_acc.acc_number, ch_iban)
+        self.assertEqual(bank_acc.ccp, '46-110-7')
+        self.assertEqual(bank_acc.acc_type, 'iban')
+
+    def test_bank_iban_lower_case(self):
+        bank_acc = self.env['res.partner.bank'].create({
+            'partner_id': self.partner.id,
+            'acc_number': ch_iban.lower(),
+        })
+        bank_acc.onchange_acc_number_set_swiss_bank()
+
+        self.assertEqual(bank_acc.bank_id, self.bank)
+        self.assertEqual(bank_acc.acc_number, ch_iban.lower())
+        self.assertEqual(bank_acc.ccp, '46-110-7')
+        self.assertEqual(bank_acc.acc_type, 'iban')
+
+    def test_bank_iban_foreign(self):
+        bank_acc = self.env['res.partner.bank'].create({
+            'partner_id': self.partner.id,
+            'acc_number': fr_iban,
+        })
+        bank_acc.onchange_acc_number_set_swiss_bank()
+
+        self.assertFalse(bank_acc.bank_id)
+        self.assertEqual(bank_acc.acc_number, fr_iban)
+        self.assertFalse(bank_acc.ccp)
+        self.assertEqual(bank_acc.acc_type, 'iban')
+
+    def test_bank_ccp(self):
+        bank_acc = self.env['res.partner.bank'].create({
+            'partner_id': self.partner.id,
+            'acc_number': '46-110-7',
+        })
+        bank_acc.onchange_acc_number_set_swiss_bank()
+
+        self.assertEqual(bank_acc.bank_id, self.bank)
+        self.assertEqual(bank_acc.acc_number, 'Bank/CCP Camptocamp')
+        self.assertEqual(bank_acc.ccp, '46-110-7')
         self.assertEqual(bank_acc.acc_type, 'bank')
+
+    def test_bank_ccp_no_found(self):
+        bank_acc = self.env['res.partner.bank'].create({
+            'partner_id': self.partner.id,
+            'acc_number': '10-8060-7',
+        })
+        bank_acc.onchange_acc_number_set_swiss_bank()
+
+        self.assertEqual(bank_acc.bank_id, self.post_bank)
+        self.assertEqual(bank_acc.acc_number, '10-8060-7')
+        self.assertEqual(bank_acc.ccp, '10-8060-7')
+        self.assertEqual(bank_acc.acc_type, 'postal')
+
+        # specify that it isn't a postal account
+        bank_acc.bank_id = self.bank
+        bank_acc.onchange_bank_set_acc_number()
+
+        self.assertEqual(bank_acc.bank_id, self.bank)
+        self.assertEqual(bank_acc.acc_number, 'Bank/CCP Camptocamp')
+        self.assertEqual(bank_acc.ccp, '10-8060-7')
+        self.assertEqual(bank_acc.acc_type, 'bank')
+
+    def test_ccp(self):
+        bank_acc = self.env['res.partner.bank'].create({
+            'partner_id': self.partner.id,
+            'acc_number': '10-8060-7',
+        })
+        bank_acc.onchange_acc_number_set_swiss_bank()
+
+        self.assertEqual(bank_acc.bank_id, self.post_bank)
+        self.assertEqual(bank_acc.acc_number, '10-8060-7')
+        self.assertEqual(bank_acc.ccp, '10-8060-7')
+        self.assertEqual(bank_acc.acc_type, 'postal')
 
     def test_iban_ccp(self):
         bank_acc = self.env['res.partner.bank'].create({
             'partner_id': self.partner.id,
-            'bank_id': self.post_bank.id,
-            'acc_number': 'CH0909000000100080607',
-            'bvr_adherent_num': '1234567',
+            'acc_number': ch_post_iban.replace(' ', ''),
         })
+        bank_acc.onchange_acc_number_set_swiss_bank()
+
+        self.assertEqual(bank_acc.bank_id, self.post_bank)
+        self.assertEqual(bank_acc.acc_number, ch_post_iban.replace(' ', ''))
         self.assertEqual(bank_acc.ccp, '10-8060-7')
         self.assertEqual(bank_acc.acc_type, 'iban')
 
     def test_iban_ccp_with_spaces(self):
         bank_acc = self.env['res.partner.bank'].create({
             'partner_id': self.partner.id,
-            'bank_id': self.post_bank.id,
-            'acc_number': 'CH09 0900 0000 1000 8060 7',
-            'bvr_adherent_num': '1234567',
+            'acc_number': ch_post_iban,
         })
+        bank_acc.onchange_acc_number_set_swiss_bank()
+
+        self.assertEqual(bank_acc.bank_id, self.post_bank)
+        self.assertEqual(bank_acc.acc_number, ch_post_iban)
         self.assertEqual(bank_acc.ccp, '10-8060-7')
         self.assertEqual(bank_acc.acc_type, 'iban')
 
-    def test_faulty_ccp_at_bank(self):
+    def test_other_bank(self):
+        self.bank.ccp = False
+        bank_acc = self.env['res.partner.bank'].create({
+            'partner_id': self.partner.id,
+            'bank_id': self.bank.id,
+            'acc_number': 'R 12312123',
+        })
+        bank_acc.onchange_acc_number_set_swiss_bank()
+
+        self.assertEqual(bank_acc.bank_id, self.bank)
+        self.assertEqual(bank_acc.acc_number, 'R 12312123')
+        self.assertEqual(bank_acc.ccp, False)
+        self.assertEqual(bank_acc.acc_type, 'bank')
+
+    def test_set_ccp(self):
+        bank_acc = self.env['res.partner.bank'].new({
+            'partner_id': self.partner.id,
+            'acc_number': None,
+            'ccp': '10-8060-7',
+        })
+        bank_acc.onchange_ccp_set_empty_acc_number()
+
+        self.assertEqual(bank_acc.acc_number, '10-8060-7')
+        self.assertEqual(bank_acc.bank_id, self.post_bank)
+
+    def test_set_ccp_bank(self):
+        bank_acc = self.env['res.partner.bank'].new({
+            'partner_id': self.partner.id,
+            'acc_number': None,
+            'bank_id': self.bank.id,
+            'ccp': '10-8060-7'
+        })
+        bank_acc.onchange_ccp_set_empty_acc_number()
+
+        self.assertEqual(bank_acc.acc_number, 'Bank/CCP Camptocamp')
+        self.assertEqual(bank_acc.bank_id, self.bank)
+
+    def test_set_ccp_post(self):
+        bank_acc = self.env['res.partner.bank'].new({
+            'partner_id': self.partner.id,
+            'acc_number': None,
+            'bank_id': self.post_bank.id,
+            'ccp': '10-8060-7'
+        })
+        bank_acc.onchange_ccp_set_empty_acc_number()
+
+        self.assertEqual(bank_acc.acc_number, '10-8060-7')
+        self.assertEqual(bank_acc.bank_id, self.post_bank)
+
+    def test_set_ccp_unknown(self):
+        bank_acc = self.env['res.partner.bank'].new({
+            'partner_id': self.partner.id,
+            'acc_number': None,
+            'ccp': '46-110-7'
+        })
+        bank_acc.onchange_ccp_set_empty_acc_number()
+
+        self.assertEqual(bank_acc.acc_number, 'Bank/CCP Camptocamp')
+        self.assertEqual(bank_acc.bank_id, self.bank)
+
+    def test_constraint_ccp(self):
         with self.assertRaises(exceptions.ValidationError):
             with mute_logger():
-                self.bank.write({
-                    'ccp': '2342342343423',
-                })
                 self.env['res.partner.bank'].create({
                     'partner_id': self.partner.id,
                     'bank_id': self.bank.id,
                     'acc_number': 'R 12312123',
-                    'bvr_adherent_num': '1234567',
+                    'ccp': '520-54025-54054',
                 })
 
-    def test_non_bvr_bank(self):
-        self.env['res.partner.bank'].create({
-            'partner_id': self.partner.id,
-            'bank_id': self.bank.id,
-            'acc_number': 'R 12312123',
-            'bvr_adherent_num': '1234567',
-        })
+    def test_constraint_ccp_at_bank(self):
+        with self.assertRaises(exceptions.ValidationError):
+            with mute_logger():
+                self.bank.ccp = '999999999999'
 
     def test_constraint_adherent_number(self):
         with self.assertRaises(exceptions.ValidationError):
@@ -72,59 +215,126 @@ class TestBank(common.TransactionCase):
                 })
 
     def test_get_account_number(self):
-        bank_account = self.env['res.partner.bank'].create({
+        """ get_account_number return ccp if defined or acc_number """
+        bank_acc = self.env['res.partner.bank'].create({
             'partner_id': self.partner.id,
-            'bank_id': self.bank.id,
             'acc_number': 'R 12312123',
             'bvr_adherent_num': '1234567',
         })
-        acc_num = bank_account.get_account_number()
-        self.assertEqual(acc_num, bank_account.acc_number)
-        self.bank.write({
-            'ccp': '01-1234-1',
-        })
-        acc_num = bank_account.get_account_number()
-        self.assertEqual(acc_num, bank_account.ccp)
+        acc_num = bank_acc.get_account_number()
+        self.assertEqual(acc_num, bank_acc.acc_number)
+        bank_acc.ccp = '10-725-4'
+        acc_num = bank_acc.get_account_number()
+        self.assertEqual(acc_num, bank_acc.ccp)
 
-    def test_onchange_bank(self):
-        self.bank.write({
-            'ccp': '01-1234-1',
-        })
-        bank_account = self.env['res.partner.bank'].new({
+    def test_onchange_bank_empty_acc_number(self):
+        bank_acc = self.env['res.partner.bank'].new({
             'partner_id': self.partner.id,
             'bank_id': self.bank.id,
             'acc_number': None,
-            'bvr_adherent_num': '1234567',
+            'ccp': '46-110-7'
         })
-        bank_account.onchange_bank()
-        self.assertEqual(bank_account.acc_number, 'Bank/CCP 01-1234-1')
+        bank_acc.onchange_bank_set_acc_number()
+        self.assertEqual(bank_acc.acc_number, 'Bank/CCP Camptocamp')
+        self.assertEqual(bank_acc.ccp, '46-110-7')
+
+    def test_onchange_post_bank_empty_acc_number(self):
+        bank_acc = self.env['res.partner.bank'].new({
+            'partner_id': self.partner.id,
+            'bank_id': self.post_bank.id,
+            'acc_number': None,
+            'ccp': '46-110-7'
+        })
+        bank_acc.onchange_bank_set_acc_number()
+        self.assertEqual(bank_acc.acc_number, '46-110-7')
+        self.assertEqual(bank_acc.ccp, '46-110-7')
+
+    def test_onchange_post_bank_ccp_in_acc_number(self):
+        bank_acc = self.env['res.partner.bank'].new({
+            'partner_id': self.partner.id,
+            'bank_id': self.post_bank.id,
+            'acc_number': '46-110-7',
+            'ccp': None,
+        })
+        bank_acc.onchange_bank_set_acc_number()
+        self.assertEqual(bank_acc.acc_number, '46-110-7')
+        self.assertEqual(bank_acc.ccp, '46-110-7')
 
     def test_name_search(self):
-        result = self.env['res.bank'].name_search('BIC23423')
-        self.bank.code = 'CODE123'
+        self.bank.bic = 'BIC12345'
+        result = self.env['res.bank'].name_search('BIC12345')
         self.assertEqual(result and result[0][0], self.bank.id)
+        self.bank.code = 'CODE123'
         result = self.env['res.bank'].name_search('CODE123')
         self.assertEqual(result and result[0][0], self.bank.id)
         self.bank.street = 'Route de Neuchâtel'
-        self.bank.city = 'Lausanne'
         result = self.env['res.bank'].name_search('Route de Neuchâtel')
         self.assertEqual(result and result[0][0], self.bank.id)
-        result = self.env['res.bank'].name_search('Lausanne')
+        self.bank.city = 'Lausanne-Centre'
+        result = self.env['res.bank'].name_search('Lausanne-Centre')
         self.assertEqual(result and result[0][0], self.bank.id)
+
+    def test_multiple_bvr_bank_account_for_same_partner(self):
+        bank_acc = self.env['res.partner.bank'].create({
+            'partner_id': self.partner.id,
+            'acc_number': '46-110-7',
+        })
+        bank_acc.onchange_acc_number_set_swiss_bank()
+
+        bank_acc2 = self.env['res.partner.bank'].create({
+            'partner_id': self.partner.id,
+            'acc_number': '46-110-7',
+        })
+        bank_acc2.onchange_acc_number_set_swiss_bank()
+
+        self.assertEqual(bank_acc2.bank_id, self.bank)
+        self.assertEqual(bank_acc2.acc_number, 'Bank/CCP Camptocamp (1)')
+        self.assertEqual(bank_acc2.acc_type, 'bank')
+
+        bank_acc.unlink()
+
+        bank_acc3 = self.env['res.partner.bank'].create({
+            'partner_id': self.partner.id,
+            'acc_number': '46-110-7',
+        })
+        bank_acc3.onchange_acc_number_set_swiss_bank()
+
+        self.assertEqual(bank_acc3.bank_id, self.bank)
+        self.assertEqual(bank_acc3.acc_number, 'Bank/CCP Camptocamp (2)')
+        self.assertEqual(bank_acc3.acc_type, 'bank')
+
+    def test_bank_ccp_no_partner(self):
+        bank_acc = self.env['res.partner.bank'].create({
+            'acc_number': '46-110-7',
+        })
+        bank_acc.onchange_acc_number_set_swiss_bank()
+
+        self.assertEqual(bank_acc.acc_number, 'Bank/CCP Undefined')
+
+        bank_acc.partner_id = self.partner
+        bank_acc.onchange_partner_set_acc_number()
+
+        self.assertEqual(bank_acc.acc_number, 'Bank/CCP Camptocamp')
+
+        bank_acc.partner_id = False
+        bank_acc.onchange_partner_set_acc_number()
+
+        self.assertEqual(bank_acc.acc_number, 'Bank/CCP Undefined')
 
     def setUp(self):
         super(TestBank, self).setUp()
-        self.partner = self.env.ref('base.main_partner')
+        self.partner = self.env.ref('base.res_partner_12')
         self.bank = self.env['res.bank'].create({
-            'name': 'BCV',
-            'bic': 'BIC23423',
-            'clearing': 'CLEAR234234',
+            'name': 'Alternative Bank Schweiz AG',
+            'bic': 'ALSWCH21XXX',
+            'clearing': '38815',
+            'ccp': '46-110-7',
         })
         self.post_bank = self.env['res.bank'].search(
             [('bic', '=', 'POFICHBEXXX')])
         if not self.post_bank:
             self.post_bank = self.env['res.bank'].create({
-                'name': 'Swiss post',
+                'name': 'PostFinance AG',
                 'bic': 'POFICHBEXXX',
-                'clearing': 'CLEAR234234',
+                'clearing': '9000',
             })

--- a/l10n_ch_pain_base/models/account_payment_order.py
+++ b/l10n_ch_pain_base/models/account_payment_order.py
@@ -90,7 +90,7 @@ class AccountPaymentOrder(models.Model):
             if not partner_bank.ccp:
                 raise UserError(_(
                     "The field 'CCP/CP-Konto' is not set on the bank "
-                    "'%s'.") % partner_bank.bank_id.name)
+                    "account '%s'.") % partner_bank.name)
             party_account = etree.SubElement(
                 parent_node, '%sAcct' % party_type)
             party_account_id = etree.SubElement(party_account, 'Id')

--- a/l10n_ch_pain_credit_transfer/tests/test_ch_sct.py
+++ b/l10n_ch_pain_credit_transfer/tests/test_ch_sct.py
@@ -8,57 +8,61 @@ from openerp.tools import float_compare
 import time
 from lxml import etree
 
+ch_iban = 'CH15 3881 5158 3845 3843 7'
+
 
 class TestSCT_CH(AccountingTestCase):
 
     def setUp(self):
         super(TestSCT_CH, self).setUp()
-        self.account_model = self.env['account.account']
-        self.move_model = self.env['account.move']
-        self.journal_model = self.env['account.journal']
-        self.payment_mode_model = self.env['account.payment.mode']
+        Account = self.env['account.account']
+        Journal = self.env['account.journal']
+        PaymentMode = self.env['account.payment.mode']
+
         self.payment_order_model = self.env['account.payment.order']
         self.payment_line_model = self.env['account.payment.line']
         self.bank_line_model = self.env['bank.payment.line']
         self.partner_bank_model = self.env['res.partner.bank']
-        self.bank_model = self.env['res.bank']
         self.attachment_model = self.env['ir.attachment']
         self.invoice_model = self.env['account.invoice']
         self.invoice_line_model = self.env['account.invoice.line']
+
         self.main_company = self.env.ref('base.main_company')
         self.partner_agrolait = self.env.ref('base.res_partner_2')
-        self.account_expense = self.account_model.search([(
+
+        self.account_expense = Account.search([(
             'user_type_id',
             '=',
             self.env.ref('account.data_account_type_expenses').id)], limit=1)
-        self.account_payable = self.account_model.search([(
+        self.account_payable = Account.search([(
             'user_type_id',
             '=',
             self.env.ref('account.data_account_type_payable').id)], limit=1)
         # Create a swiss bank
-        ch_bank = self.bank_model.create({
-            'name': 'Big swiss bank',
-            'bic': 'DRESDEFF300',
-            'ccp': '01-1234-1',
-            })
+        ch_bank1 = self.env['res.bank'].create({
+            'name': 'Alternative Bank Schweiz AG',
+            'bic': 'ALSWCH21XXX',
+            'clearing': '38815',
+            'ccp': '46-110-7',
+        })
         # create a ch bank account for my company
-        self.agrolait_partner_bank = self.partner_bank_model.create({
-            'acc_number': 'CH0909000000100080607',
+        self.cp_partner_bank = self.partner_bank_model.create({
+            'acc_number': ch_iban,
             'partner_id': self.env.ref('base.main_partner').id,
-            'bank_id': ch_bank.id,
             })
+        self.cp_partner_bank.onchange_acc_number_set_swiss_bank()
         # create journal
-        self.bank_journal = self.journal_model.create({
+        self.bank_journal = Journal.create({
             'name': 'Company Bank journal',
             'type': 'bank',
             'code': 'BNKFB',
-            'bank_account_id': self.agrolait_partner_bank.id,
-            'bank_id': ch_bank.id,
+            'bank_account_id': self.cp_partner_bank.id,
+            'bank_id': ch_bank1.id,
             })
         # create a payment mode
         pay_method_id = self.env.ref(
             'account_banking_sepa_credit_transfer.sepa_credit_transfer').id
-        self.payment_mode = self.payment_mode_model.create({
+        self.payment_mode = PaymentMode.create({
             'name': 'CH credit transfer',
             'bank_account_link': 'fixed',
             'fixed_journal_id': self.bank_journal.id,
@@ -69,11 +73,18 @@ class TestSCT_CH(AccountingTestCase):
         self.chf_currency = self.env.ref('base.CHF')
         self.eur_currency = self.env.ref('base.EUR')
         self.main_company.currency_id = self.chf_currency.id
-        # Create a bank account
+        ch_bank2 = self.env['res.bank'].create({
+            'name': 'Banque Cantonale Vaudoise',
+            'bic': 'BCVLCH2LXXX',
+            'clearing': '767',
+            'ccp': '01-1234-1',
+        })
+        # Create a bank account with clearing 767
         self.agrolait_partner_bank = self.partner_bank_model.create({
             'acc_number': 'CH9100767000S00023455',
             'partner_id': self.partner_agrolait.id,
-            'bank_id': ch_bank.id,
+            'bank_id': ch_bank2.id,
+            'ccp': '01-1234-1',
             })
 
     def test_sct_ch_payment_type1(self):

--- a/l10n_ch_payment_slip/tests/test_payment_slip.py
+++ b/l10n_ch_payment_slip/tests/test_payment_slip.py
@@ -29,13 +29,15 @@ class TestPaymentSlip(test_common.TransactionCase):
                 'partner_id': partner.id,
                 'bank_id': bank.id,
                 'bank_bic': bank.bic,
-                'acc_number': 'R 12312123',
+                'acc_number': '01-1234-1',
                 'bvr_adherent_num': '1234567',
                 'print_bank': True,
                 'print_account': True,
                 'print_partner': True,
             }
         )
+        bank_account.onchange_acc_number_set_swiss_bank()
+        self.assertEqual(bank_account.ccp, '01-1234-1')
         return bank_account
 
     def make_invoice(self):

--- a/l10n_ch_payment_slip/tests/test_payment_slip.py
+++ b/l10n_ch_payment_slip/tests/test_payment_slip.py
@@ -4,8 +4,10 @@
 import time
 import re
 
+from openerp import tools
 import openerp.tests.common as test_common
 from openerp.report import render_report
+from openerp.modules.module import get_module_resource
 
 
 class TestPaymentSlip(test_common.TransactionCase):
@@ -44,8 +46,8 @@ class TestPaymentSlip(test_common.TransactionCase):
         if not hasattr(self, 'bank_account'):
             self.bank_account = self.make_bank()
         account_model = self.env['account.account']
-        account_debtor = account_model.search([('code', '=', '1100')])
-        account_sale = account_model.search([('code', '=', '3200')])
+        account_debtor = account_model.search([('code', '=', 'X1012')])
+        account_sale = account_model.search([('code', '=', 'X2020')])
 
         invoice = self.env['account.invoice'].create({
             'partner_id': self.env.ref('base.res_partner_12').id,
@@ -208,3 +210,13 @@ class TestPaymentSlip(test_common.TransactionCase):
             address_lines,
             [u'93, Press Avenue', u'73377 Le Bourget du Lac']
         )
+
+    def _load(self, module, *args):
+        tools.convert_file(
+            self.cr, 'account_asset',
+            get_module_resource(module, *args),
+            {}, 'init', False, 'test', self.registry._assertion_report)
+
+    def setUp(self):
+        super(TestPaymentSlip, self).setUp()
+        self._load('account', 'test', 'account_minimal_test.xml')


### PR DESCRIPTION
Set the bank when possible
and set ccp when undefined

Bank is defined as:
- Found bank with CCP matching Bank CCP
- Swiss post when CCP is no matching a Bank CCP
- Found bank by clearing when using iban

For CCP it can be:
- a postal account, we copy acc_number
- a postal account in iban format, we transform acc_number
- a bank account with CCP on the bank, we use ccp of the bank
- otherwise there is no CCP to use
