### PR TITLE
Allow whitespaces in search of invoice references

### DIFF
--- a/l10n_ch_base_bank/models/invoice.py
+++ b/l10n_ch_base_bank/models/invoice.py
@@ -11,6 +11,37 @@ class AccountInvoice(models.Model):
 
     _inherit = "account.invoice"
 
+    def _search(self, args, offset=0, limit=None, order=None, count=False,
+                access_rights_uid=None):
+        domain = []
+        for arg in args:
+            if not isinstance(arg, (tuple, list)) or len(arg) != 3:
+                domain.append(arg)
+                continue
+            field, operator, value = arg
+            if field != 'reference':
+                domain.append(arg)
+                continue
+            if operator not in ('like', 'ilike', '=like', '=ilike',
+                                'not like', 'not ilike', '=',
+                                '!=', '<', '<=', '>', '>=', 'in', 'not in'):
+                domain.append(arg)
+                continue
+            if value:
+                value = value.replace(' ', '')
+                if operator in ('like', 'ilike', 'not like', 'not ilike'):
+                    value = '%%%s%%' % (value,)
+            query = ("SELECT id FROM account_invoice "
+                     "WHERE REPLACE(reference, ' ', '') %s %%s" %
+                     (operator,))
+            self.env.cr.execute(query, (value,))
+            ids = [t[0] for t in self.env.cr.fetchall()]
+            domain.append(('id', 'in', ids))
+
+        return super(AccountInvoice, self)._search(
+            domain, offset=offset, limit=limit, order=order, count=count,
+            access_rights_uid=access_rights_uid)
+
     @api.model
     def _get_reference_type(self):
         selection = super(AccountInvoice, self)._get_reference_type()

--- a/l10n_ch_base_bank/tests/__init__.py
+++ b/l10n_ch_base_bank/tests/__init__.py
@@ -4,3 +4,4 @@
 from . import test_bank
 from . import test_bank_type
 from . import test_create_invoice
+from . import test_search_invoice

--- a/l10n_ch_base_bank/tests/test_search_invoice.py
+++ b/l10n_ch_base_bank/tests/test_search_invoice.py
@@ -59,13 +59,13 @@ class TestSearchInvoice(common.TransactionCase):
         )
 
     def test_search_equal_whitespace_right(self):
-        self.assert_find_ref(
+        self.assert_not_find_ref(
             '272999000000000017040025019',
             '=', '27 29990 00000 00001 70400 25019'
         )
 
     def test_search_equal_whitespace_left(self):
-        self.assert_find_ref(
+        self.assert_not_find_ref(
             '27 29990 00000 00001 70400 25019',
             '=', '272999000000000017040025019'
         )
@@ -86,6 +86,18 @@ class TestSearchInvoice(common.TransactionCase):
             'like', '17 040025 01'
         )
 
+    def test_search_eqlike_whitespace_raw(self):
+        self.assert_not_find_ref(
+            '27 29990 00000 00001 70400 25019',
+            '=like', '17 040025 01'
+        )
+
+    def test_search_eqlike_whitespace_wildcards(self):
+        self.assert_find_ref(
+            '27 29990 00000 00001 70400 25019',
+            '=like', '%17 040025 01%'
+        )
+
     def test_search_different(self):
         self.assert_not_find_ref(
             '27 29990 00000 00001 70400 25019', 'like', '4273473'
@@ -101,5 +113,21 @@ class TestSearchInvoice(common.TransactionCase):
         invoice = self.env['account.invoice'].create(values)
         found = self.env['account.invoice'].search(
             [('partner_id', '=', self.partner.id)],
+        )
+        self.assertEqual(invoice, found)
+
+    def test_search_unary_operator(self):
+        values = {
+            'partner_id': self.partner.id,
+            'type': 'out_invoice',
+            'reference_type': 'bvr',
+            'reference': '27 29990 00000 00001 70400 25019',
+        }
+        invoice = self.env['account.invoice'].create(values)
+        found = self.env['account.invoice'].search(
+            ['|',
+             ('partner_id', '=', False),
+             ('reference', 'like', '2999000000'),
+             ],
         )
         self.assertEqual(invoice, found)

--- a/l10n_ch_base_bank/tests/test_search_invoice.py
+++ b/l10n_ch_base_bank/tests/test_search_invoice.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests import common
+
+
+class TestSearchInvoice(common.TransactionCase):
+
+    def setUp(self):
+        super(TestSearchInvoice, self).setUp()
+        self.company = self.env.ref('base.main_company')
+        bank = self.env['res.bank'].create({
+            'name': 'BCV',
+            'bic': 'BIC23423',
+            'clearing': '234234',
+            'ccp': '01-1234-1',
+        })
+        bank_account = self.env['res.partner.bank'].create({
+            'partner_id': self.company.partner_id.id,
+            'bank_id': bank.id,
+            'acc_number': 'Bank/CCP 01-1234-1',
+        })
+        self.company.partner_id.bank_ids = bank_account
+        self.partner = self.env['res.partner'].create(
+            {'name': 'Test'}
+        )
+
+    def assert_find_ref(self, reference, operator, value):
+        values = {
+            'partner_id': self.partner.id,
+            'type': 'out_invoice',
+            'reference_type': 'bvr',
+            'reference': reference,
+        }
+        invoice = self.env['account.invoice'].create(values)
+        found = self.env['account.invoice'].search(
+            [('reference', operator, value)],
+        )
+        self.assertEqual(invoice, found)
+
+    def assert_not_find_ref(self, reference, operator, value):
+        values = {
+            'partner_id': self.partner.id,
+            'type': 'out_invoice',
+            'reference_type': 'bvr',
+            'reference': reference,
+        }
+        self.env['account.invoice'].create(values)
+        found = self.env['account.invoice'].search(
+            [('reference', operator, value)],
+        )
+        self.assertFalse(found)
+
+    def test_search_equal_strict(self):
+        self.assert_find_ref(
+            '27 29990 00000 00001 70400 25019',
+            '=', '27 29990 00000 00001 70400 25019'
+        )
+
+    def test_search_equal_whitespace_right(self):
+        self.assert_find_ref(
+            '272999000000000017040025019',
+            '=', '27 29990 00000 00001 70400 25019'
+        )
+
+    def test_search_equal_whitespace_left(self):
+        self.assert_find_ref(
+            '27 29990 00000 00001 70400 25019',
+            '=', '272999000000000017040025019'
+        )
+
+    def test_search_like_whitespace_right(self):
+        self.assert_find_ref(
+            '272999000000000017040025019', 'like', '1 70400 25'
+        )
+
+    def test_search_like_whitespace_left(self):
+        self.assert_find_ref(
+            '27 29990 00000 00001 70400 25019', 'like', '17040025'
+        )
+
+    def test_search_like_whitespace_both(self):
+        self.assert_find_ref(
+            '27 29990 00000 00001 70400 25019',
+            'like', '17 040025 01'
+        )
+
+    def test_search_different(self):
+        self.assert_not_find_ref(
+            '27 29990 00000 00001 70400 25019', 'like', '4273473'
+        )
+
+    def test_search_other_field(self):
+        values = {
+            'partner_id': self.partner.id,
+            'type': 'out_invoice',
+            'reference_type': 'bvr',
+            'reference': '27 29990 00000 00001 70400 25019',
+        }
+        invoice = self.env['account.invoice'].create(values)
+        found = self.env['account.invoice'].search(
+            [('partner_id', '=', self.partner.id)],
+        )
+        self.assertEqual(invoice, found)


### PR DESCRIPTION
When searching in Vendor references, we want to ignore the whitespaces.
This is because very often, it will contain BVR/ESR number that contains
whitespaces. And the user usually searches for the invoice number which
is only a part of the BVR/ESR number.

Example:
* the vendor reference on the supplier invoice is: 27 29990 00000 00001 70400 25019
* the user knows the invoice's supplier reference: 17040025
* when searching 17040025, he expects to find the invoice
* the reverse situation, where the ref contains no whitespaces and the
  user searches for a string with whitespaces might also happen