### PR TITLE
Contraint on BVR adherent number / CPP pair

### DIFF
--- a/l10n_ch_base_bank/models/bank.py
+++ b/l10n_ch_base_bank/models/bank.py
@@ -349,5 +349,5 @@ class ResPartnerBank(models.Model, BankCommon):
             if 'Bank/CCP' in self.acc_number:
                 self.acc_number = self._get_acc_name()
 
-    _sql_constraints = [('bvr_adherent_uniq', 'unique (bvr_adherent_num)',
-                         'The BVR adherent number must be unique !')]
+    _sql_constraints = [('bvr_adherent_uniq', 'unique (bvr_adherent_num, ccp)',
+                         'The BVR adherent number/ccp pair must be unique !')]


### PR DESCRIPTION
First of all there is a confusion for the BVR coding line:
0100000600007>103559000000000020170013270+ 100007254>
.....................................^ reference beginning with......................^ adherent number
.....................................bank client account number
.....................................( 6 chars )
You are naming the 6 chars client account number as BVR adherent number which is false.
Here Raiffeisen documentation : [Raiffeisen doc pdf](https://www.raiffeisen.ch/content/dam/www/rch/pdf/firmenkunden/zahlungsverkehr-und-konten/fr/fiche-produit-bulletin-versement-orange.pdf)
However, both of these numbers can be used many times but the pair (adherent number / client account number) must be unique.