### PR TITLE
[9.0] DTA: Use aggregated bank_lines instead of payment_lines

### DIFF
--- a/l10n_ch_dta/wizard/create_dta.py
+++ b/l10n_ch_dta/wizard/create_dta.py
@@ -616,12 +616,7 @@ class DTAFileGenerator(models.TransientModel):
         elec_context['partner_bank_country'] = b_country
 
         elec_context['partner_bank_code'] = pline.partner_bank_id.bank_bic
-        elec_context['reference'] = False
-        if hasattr(pline.move_line_id, 'transaction_ref'):
-            if pline.move_line_id.transaction_ref:
-                elec_context['reference'] = pline.move_line_id.transaction_ref
-        if not elec_context['reference']:
-            elec_context['reference'] = pline.move_line_id.ref
+        elec_context['reference'] = pline.communication or False
         # Add support for owner of the account if exists..
         p_name = pline.partner_id.name if pline.partner_id else ''
         elec_context['partner_name'] = p_name
@@ -708,7 +703,7 @@ class DTAFileGenerator(models.TransientModel):
         seq = 1
         amount_tot = 0
 
-        for pline in payment.payment_line_ids:
+        for pline in payment.bank_line_ids:
             elec_context = self._process_payment_lines(
                 data, pline,
                 elec_context, seq


### PR DESCRIPTION
Currently the DTA is created based on the payment_lines that ahave a 1:1
 relation to account_move_lines. Especially to pay expenses this creates
 a transaction for each expense.
 bank_lines (already existing) have merged all payments to the same
 partner when there is no structured communication used. It is better to
 use bank_lines.

 Payment to the same partner but with different BVR are
 not merged!