### PR TITLE
[FIX] write BVR adherent number on bank account when the user select …

### DIFF
--- a/l10n_ch_scan_bvr/wizard/scan_bvr.py
+++ b/l10n_ch_scan_bvr/wizard/scan_bvr.py
@@ -362,6 +362,11 @@ class ScanBvr(models.TransientModel):
             data['partner_id'] = self.partner_id.id
             data['journal_id'] = self.journal_id.id
             data['bank_account'] = self.bank_account_id.id
+            # We will write the adherent BVR number if we have one
+            # for the futur invoice
+            if data['bvr_struct']['domain'] == 'bvr_adherent_num':
+                self.bank_account_id.bvr_adherent_num = \
+                    data['bvr_struct']['bvrnumber']
             action = self._create_direct_invoice(data)
             return action
         else:


### PR DESCRIPTION
When you scan an new supplier invoice, you need to
create the account but you don't know the bvr adherent number (is it stored in the BVR scan line).

So you scan the BVR Scan line with you paypen in the scan BVR view, it will search for a bank account with the bvr adhrerent number reference stored in the scan line
but it will be not found , so you select the partner and the account manually.

currently you need to find yourself the bvr adherent number in the scan line report it on the partner bank account, to be able to find find it directly.

with this PR you just need to select the account the first time, it will copy the bvr adherent number found in the scan line into the related bank account.

The next time the correct bank account will be found directly.
