### PR TITLE
[8.0] Wrap import of wand in try except

### DIFF
--- a/l10n_ch_account_statement_base_import/parsers/postfinance_file_parser.py
+++ b/l10n_ch_account_statement_base_import/parsers/postfinance_file_parser.py
@@ -22,7 +22,7 @@ from os.path import splitext
 from tarfile import TarFile, TarError
 from cStringIO import StringIO
 from lxml import etree
-from wand.image import Image
+
 import logging
 
 from openerp import fields
@@ -31,6 +31,11 @@ from .camt import PFCamtParser
 from .base_parser import BaseSwissParser
 
 _logger = logging.getLogger(__name__)
+
+try:
+    from wand.image import Image
+except ImportError:
+    _logger.debug('Cannot `from wand.image import Image`')
 
 
 class XMLPFParser(BaseSwissParser):


### PR DESCRIPTION
This avoid an error if the module is not installed and wand is not present.
This is due to the static folder making the module loaded anyway.