### PR TITLE
[9.0] Fix import of uncompressed PostFinance camt files

### DIFF
--- a/l10n_ch_bank_statement_import_postfinance/models/postfinance_file_parser.py
+++ b/l10n_ch_bank_statement_import_postfinance/models/postfinance_file_parser.py
@@ -83,8 +83,7 @@ class XMLPFParser(models.AbstractModel):
         """
         self.tar_source = data_file
         self.data_file = self._get_content_from_stream()
-        if self.is_tar:
-            self.attachments = self._get_attachments_from_stream(data_file)
+        self.attachments = self._get_attachments_from_stream(data_file)
 
     def _get_content_from_stream(self):
         """Source file can be a raw or tar file. We try to guess the

--- a/l10n_ch_bank_statement_import_postfinance/tests/test_postfinance_xml.py
+++ b/l10n_ch_bank_statement_import_postfinance/tests/test_postfinance_xml.py
@@ -69,7 +69,7 @@ class PFXMLParserTest(common.TransactionCase):
         self.assertIsNotNone(self.parser.attachments)
         self.parser.attachments = None
         self.parser._check_postfinance_attachments('BANG')
-        self.assertIsNone(self.parser.attachments)
+        self.assertEqual(self.parser.attachments, {})
 
     def test_parse(self):
         """Test file is correctly parsed"""


### PR DESCRIPTION
Import of uncompressed PostFinance-generated camt files currently fails, as in this scenario, the parser's `self.attachments` variable is never initialized but is still accessed in the `parse` method, leading to an AttributeError being raised.

This simple fix works because the `_get_attachments_from_stream` method correctly handles untarred files - by setting `self.attachments` to an empty dict.