### PR TITLE
[UPDATE] Changed Non-ASCII character

### DIFF
--- a/l10n_ch_base_bank/i18n/de.po
+++ b/l10n_ch_base_bank/i18n/de.po
@@ -6,10 +6,10 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-19 00:40+0000\n"
-"PO-Revision-Date: 2017-04-19 00:40+0000\n"
+"POT-Creation-Date: 2017-12-01 21:23+0000\n"
+"PO-Revision-Date: 2017-12-01 21:23+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
 "MIME-Version: 1.0\n"
@@ -19,28 +19,28 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:56
+#: code:addons/l10n_ch_base_bank/models/invoice.py:58
 #, python-format
 msgid "BVR Reference"
-msgstr "BVR Referenznummer"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:99
+#: code:addons/l10n_ch_base_bank/models/invoice.py:101
 #, python-format
 msgid "BVR/ESR Reference is required"
-msgstr "BVR/ESR Referenznummer ist erforderlich"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:80
+#: code:addons/l10n_ch_base_bank/models/invoice.py:82
 #, python-format
 msgid "BVR/ESR Reference type needs a postal account number on the customer."
-msgstr "BVR/ESR Referenznummer benötigt eine Postkonto Nummer beim Kunden."
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:85
+#: code:addons/l10n_ch_base_bank/models/invoice.py:87
 #, python-format
 msgid "BVR/ESR Reference type needs a postal account number on your company"
-msgstr "BVR/ESR Referenznummer benötigt eine Postkonto Nummer bei der Firma."
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model,name:l10n_ch_base_bank.model_res_bank
@@ -50,21 +50,21 @@ msgstr "Bank"
 #. module: l10n_ch_base_bank
 #: model:ir.model,name:l10n_ch_base_bank.model_res_partner_bank
 msgid "Bank Accounts"
-msgstr "Bankkonten"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,field_description:l10n_ch_base_bank.field_res_partner_bank_bvr_adherent_num
 msgid "Bank BVR/ESR adherent number"
-msgstr "Die zur Bank zugehörige BVR/ESR Nummer"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/bank.py:241
+#: code:addons/l10n_ch_base_bank/models/bank.py:242
 #, python-format
 msgid "Bank/CCP Undefined"
 msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/bank.py:239
+#: code:addons/l10n_ch_base_bank/models/bank.py:240
 #, python-format
 msgid "Bank/CCP {}"
 msgstr ""
@@ -72,7 +72,7 @@ msgstr ""
 #. module: l10n_ch_base_bank
 #: model:ir.ui.view,arch_db:l10n_ch_base_bank.view_bank_search
 msgid "Banks"
-msgstr "Banken"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,field_description:l10n_ch_base_bank.field_res_bank_ccp
@@ -93,47 +93,45 @@ msgstr ""
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,field_description:l10n_ch_base_bank.field_res_bank_code
 msgid "Code"
-msgstr "Code"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,help:l10n_ch_base_bank.field_res_bank_code
 msgid "Internal reference"
-msgstr "Interne Referenznummer"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:111
+#: code:addons/l10n_ch_base_bank/models/invoice.py:113
 #, python-format
 msgid "Invalid BVR/ESR Number (wrong checksum)."
-msgstr "Ungültige BVR/ESR Nummer (Falsche Prüfziffer)."
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model,name:l10n_ch_base_bank.model_account_invoice
 msgid "Invoice"
-msgstr "Rechnung"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/bank.py:111
-#: code:addons/l10n_ch_base_bank/models/bank.py:226
+#: code:addons/l10n_ch_base_bank/models/bank.py:110
+#: code:addons/l10n_ch_base_bank/models/bank.py:227
 #, python-format
 msgid "Please enter a correct postal number. (01-23456-1 or 12345)"
 msgstr ""
-"Bitte geben Sie eine korrekte Postkonto Nummer ein. (01-23456-1 or 12345)"
 
 #. module: l10n_ch_base_bank
 #: model:ir.ui.view,arch_db:l10n_ch_base_bank.view_bank_search
 msgid "PostFinance"
-msgstr "PostFinance"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,help:l10n_ch_base_bank.field_res_bank_clearing
 msgid "Swiss unique bank identifier also used in IBAN number"
 msgstr ""
-"Schweizer Bank identifizierungs Nummer, ebenfalls benutzt in der IBAN Nummer"
 
 #. module: l10n_ch_base_bank
 #: sql_constraint:res.partner.bank:0
-msgid "The BVR adherent number must be unique !"
-msgstr "Die zugehörige BVR Nummer muss eindeutig sein!"
+msgid "The BVR adherent number/ccp pair must be unique !"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,help:l10n_ch_base_bank.field_res_partner_bank_bvr_adherent_num
@@ -141,15 +139,11 @@ msgid ""
 "Your Bank adherent number to be printed in references of your BVR/ESR. This "
 "is not a postal account number."
 msgstr ""
-"Die Banknummer, welche als Referenz zur BVR/ESR Nummer gedruckt wird. Dies "
-"ist nicht die Postkontonummer."
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/bank.py:213
+#: code:addons/l10n_ch_base_bank/models/bank.py:214
 #, python-format
 msgid ""
 "Your bank BVR/ESR adherent number must contain only digits!\n"
 "Please check your company bank account."
 msgstr ""
-"Ihre zur Bank zugehörige BVR/ESR Nummer darf nur Ziffern enthalten.\n"
-"Bitte überprüfen Sie die Bankkontoeinstellungen der Firma"

--- a/l10n_ch_base_bank/i18n/fr.po
+++ b/l10n_ch_base_bank/i18n/fr.po
@@ -6,10 +6,10 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-19 00:40+0000\n"
-"PO-Revision-Date: 2017-04-19 00:40+0000\n"
+"POT-Creation-Date: 2017-12-01 21:23+0000\n"
+"PO-Revision-Date: 2017-12-01 21:23+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
 "MIME-Version: 1.0\n"
@@ -19,31 +19,28 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:56
+#: code:addons/l10n_ch_base_bank/models/invoice.py:58
 #, python-format
 msgid "BVR Reference"
-msgstr "Référence BVR"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:99
+#: code:addons/l10n_ch_base_bank/models/invoice.py:101
 #, python-format
 msgid "BVR/ESR Reference is required"
-msgstr "La référence BVR est requise"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:80
+#: code:addons/l10n_ch_base_bank/models/invoice.py:82
 #, python-format
 msgid "BVR/ESR Reference type needs a postal account number on the customer."
 msgstr ""
-"Le type de référence BVR nécessite un numéro de compte postal sur le client."
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:85
+#: code:addons/l10n_ch_base_bank/models/invoice.py:87
 #, python-format
 msgid "BVR/ESR Reference type needs a postal account number on your company"
 msgstr ""
-"Le type de référence BVR nécessite un numéro de compte postal sur votre "
-"compagnie."
 
 #. module: l10n_ch_base_bank
 #: model:ir.model,name:l10n_ch_base_bank.model_res_bank
@@ -53,21 +50,21 @@ msgstr "Banque"
 #. module: l10n_ch_base_bank
 #: model:ir.model,name:l10n_ch_base_bank.model_res_partner_bank
 msgid "Bank Accounts"
-msgstr "Comptes bancaires"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,field_description:l10n_ch_base_bank.field_res_partner_bank_bvr_adherent_num
 msgid "Bank BVR/ESR adherent number"
-msgstr "Numéro d'adhérent BVR"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/bank.py:241
+#: code:addons/l10n_ch_base_bank/models/bank.py:242
 #, python-format
 msgid "Bank/CCP Undefined"
 msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/bank.py:239
+#: code:addons/l10n_ch_base_bank/models/bank.py:240
 #, python-format
 msgid "Bank/CCP {}"
 msgstr ""
@@ -75,66 +72,66 @@ msgstr ""
 #. module: l10n_ch_base_bank
 #: model:ir.ui.view,arch_db:l10n_ch_base_bank.view_bank_search
 msgid "Banks"
-msgstr "Banques"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,field_description:l10n_ch_base_bank.field_res_bank_ccp
 #: model:ir.model.fields,field_description:l10n_ch_base_bank.field_res_partner_bank_ccp
 msgid "CCP/CP-Konto"
-msgstr "Compte CCP/CP"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,help:l10n_ch_base_bank.field_res_bank_ccp
 msgid "CCP/CP-Konto of the bank"
-msgstr "Compte CCP/CP de la banque"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,field_description:l10n_ch_base_bank.field_res_bank_clearing
 msgid "Clearing number"
-msgstr "Numéro de clearing"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,field_description:l10n_ch_base_bank.field_res_bank_code
 msgid "Code"
-msgstr "Code"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,help:l10n_ch_base_bank.field_res_bank_code
 msgid "Internal reference"
-msgstr "Référence interne"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:111
+#: code:addons/l10n_ch_base_bank/models/invoice.py:113
 #, python-format
 msgid "Invalid BVR/ESR Number (wrong checksum)."
-msgstr "Numéro BVR invalide"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model,name:l10n_ch_base_bank.model_account_invoice
 msgid "Invoice"
-msgstr "Facture"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/bank.py:111
-#: code:addons/l10n_ch_base_bank/models/bank.py:226
+#: code:addons/l10n_ch_base_bank/models/bank.py:110
+#: code:addons/l10n_ch_base_bank/models/bank.py:227
 #, python-format
 msgid "Please enter a correct postal number. (01-23456-1 or 12345)"
-msgstr "Merci d'entrer un numéro postal correct (01-23456-1 ou 12345)."
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.ui.view,arch_db:l10n_ch_base_bank.view_bank_search
 msgid "PostFinance"
-msgstr "PostFinance"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,help:l10n_ch_base_bank.field_res_bank_clearing
 msgid "Swiss unique bank identifier also used in IBAN number"
-msgstr "Identifiant Suisse unique de la banque, utilisé dans le numéro IBAN"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: sql_constraint:res.partner.bank:0
-msgid "The BVR adherent number must be unique !"
-msgstr "Le numéro d'adhérent BVR doit être unique"
+msgid "The BVR adherent number/ccp pair must be unique !"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,help:l10n_ch_base_bank.field_res_partner_bank_bvr_adherent_num
@@ -142,15 +139,11 @@ msgid ""
 "Your Bank adherent number to be printed in references of your BVR/ESR. This "
 "is not a postal account number."
 msgstr ""
-"Votre numéro d'adhérent qui doit être imprimé dans la référence du BVR. Ce "
-"n'est pas un code postal."
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/bank.py:213
+#: code:addons/l10n_ch_base_bank/models/bank.py:214
 #, python-format
 msgid ""
 "Your bank BVR/ESR adherent number must contain only digits!\n"
 "Please check your company bank account."
 msgstr ""
-"Votre numéro d'adhérent BVR/ESR de votre banque ne doit contenir que des chiffres!\n"
-"Veuillez vérifier le compte bancaire de votre société"

--- a/l10n_ch_base_bank/i18n/it.po
+++ b/l10n_ch_base_bank/i18n/it.po
@@ -6,10 +6,10 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-19 00:40+0000\n"
-"PO-Revision-Date: 2017-04-19 00:40+0000\n"
+"POT-Creation-Date: 2017-12-01 21:23+0000\n"
+"PO-Revision-Date: 2017-12-01 21:23+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
 "MIME-Version: 1.0\n"
@@ -19,28 +19,28 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:56
+#: code:addons/l10n_ch_base_bank/models/invoice.py:58
 #, python-format
 msgid "BVR Reference"
-msgstr "BVR Reference"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:99
+#: code:addons/l10n_ch_base_bank/models/invoice.py:101
 #, python-format
 msgid "BVR/ESR Reference is required"
-msgstr "BVR/ESR Reference is required"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:80
+#: code:addons/l10n_ch_base_bank/models/invoice.py:82
 #, python-format
 msgid "BVR/ESR Reference type needs a postal account number on the customer."
-msgstr "BVR/ESR Reference type needs a postal account number on the customer."
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:85
+#: code:addons/l10n_ch_base_bank/models/invoice.py:87
 #, python-format
 msgid "BVR/ESR Reference type needs a postal account number on your company"
-msgstr "BVR/ESR Reference type needs a postal account number on your company"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model,name:l10n_ch_base_bank.model_res_bank
@@ -50,21 +50,21 @@ msgstr "Banca"
 #. module: l10n_ch_base_bank
 #: model:ir.model,name:l10n_ch_base_bank.model_res_partner_bank
 msgid "Bank Accounts"
-msgstr "Conti Bancari"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,field_description:l10n_ch_base_bank.field_res_partner_bank_bvr_adherent_num
 msgid "Bank BVR/ESR adherent number"
-msgstr "Bank BVR/ESR adherent number"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/bank.py:241
+#: code:addons/l10n_ch_base_bank/models/bank.py:242
 #, python-format
 msgid "Bank/CCP Undefined"
 msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/bank.py:239
+#: code:addons/l10n_ch_base_bank/models/bank.py:240
 #, python-format
 msgid "Bank/CCP {}"
 msgstr ""
@@ -72,66 +72,66 @@ msgstr ""
 #. module: l10n_ch_base_bank
 #: model:ir.ui.view,arch_db:l10n_ch_base_bank.view_bank_search
 msgid "Banks"
-msgstr "Banche"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,field_description:l10n_ch_base_bank.field_res_bank_ccp
 #: model:ir.model.fields,field_description:l10n_ch_base_bank.field_res_partner_bank_ccp
 msgid "CCP/CP-Konto"
-msgstr "CCP/CP-Conto"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,help:l10n_ch_base_bank.field_res_bank_ccp
 msgid "CCP/CP-Konto of the bank"
-msgstr "CCP/CP-Conto della banca"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,field_description:l10n_ch_base_bank.field_res_bank_clearing
 msgid "Clearing number"
-msgstr "Numero di clearing"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,field_description:l10n_ch_base_bank.field_res_bank_code
 msgid "Code"
-msgstr "Codice"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,help:l10n_ch_base_bank.field_res_bank_code
 msgid "Internal reference"
-msgstr "Riferimento interno"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/invoice.py:111
+#: code:addons/l10n_ch_base_bank/models/invoice.py:113
 #, python-format
 msgid "Invalid BVR/ESR Number (wrong checksum)."
-msgstr "Numero BVR/ESR errato (checksum invalido)."
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model,name:l10n_ch_base_bank.model_account_invoice
 msgid "Invoice"
-msgstr "Fattura"
+msgstr ""
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/bank.py:111
-#: code:addons/l10n_ch_base_bank/models/bank.py:226
+#: code:addons/l10n_ch_base_bank/models/bank.py:110
+#: code:addons/l10n_ch_base_bank/models/bank.py:227
 #, python-format
 msgid "Please enter a correct postal number. (01-23456-1 or 12345)"
-msgstr "Inserire il numero corretto del conto postale. (es. 01-23456-1)"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.ui.view,arch_db:l10n_ch_base_bank.view_bank_search
 msgid "PostFinance"
-msgstr "PostFinance"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,help:l10n_ch_base_bank.field_res_bank_clearing
 msgid "Swiss unique bank identifier also used in IBAN number"
-msgstr "Swiss unique bank identifier also used in IBAN number"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: sql_constraint:res.partner.bank:0
-msgid "The BVR adherent number must be unique !"
-msgstr "Il numero di adesione PVR deve essere univoco"
+msgid "The BVR adherent number/ccp pair must be unique !"
+msgstr ""
 
 #. module: l10n_ch_base_bank
 #: model:ir.model.fields,help:l10n_ch_base_bank.field_res_partner_bank_bvr_adherent_num
@@ -139,11 +139,9 @@ msgid ""
 "Your Bank adherent number to be printed in references of your BVR/ESR. This "
 "is not a postal account number."
 msgstr ""
-"Your Bank adherent number to be printed in references of your BVR/ESR. This "
-"is not a postal account number."
 
 #. module: l10n_ch_base_bank
-#: code:addons/l10n_ch_base_bank/models/bank.py:213
+#: code:addons/l10n_ch_base_bank/models/bank.py:214
 #, python-format
 msgid ""
 "Your bank BVR/ESR adherent number must contain only digits!\n"

--- a/l10n_ch_zip/i18n/de.po
+++ b/l10n_ch_zip/i18n/de.po
@@ -3,14 +3,14 @@
 # * l10n_ch_zip
 # 
 # Translators:
-# TT <toni.tanner@leegroup.ch>, 2017
+# OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-04 03:30+0000\n"
-"PO-Revision-Date: 2017-02-04 03:30+0000\n"
-"Last-Translator: TT <toni.tanner@leegroup.ch>, 2017\n"
+"POT-Creation-Date: 2017-12-01 21:23+0000\n"
+"PO-Revision-Date: 2017-12-01 21:23+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,7 +21,7 @@ msgstr ""
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_active
 msgid "Active"
-msgstr "Aktiv"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,help:l10n_ch_zip.field_res_better_zip_lang2
@@ -30,19 +30,16 @@ msgid ""
 "One alternative language code may appear for each postcode.\n"
 "1 = German, 2 = French, 3 = Italian, 4 = Romansh."
 msgstr ""
-"Zusätzliche Sprache innerhalb der Postleitzahl.\n"
-"Ein anderer Sprachcode kann für jede Postleitzahl in Erscheinung treten.\n"
-"1=Deutsch, 2=Französisch, 3=Italienisch, 4=Rätoromanisch"
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_additional_digit
 msgid "Additional poscode digits"
-msgstr "Zusätzliche Ziffern der Postleitzahl"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_lang2
 msgid "Alternative language code"
-msgstr "Alternativer Sprachcode"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model,name:l10n_ch_zip.model_res_better_zip
@@ -52,7 +49,7 @@ msgstr ""
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_communitynumber_bfs
 msgid "FSO municipality number (BFSNR)"
-msgstr "Gemeindenummer nach dem Bundesamt für Statistik (BFSNR)"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,help:l10n_ch_zip.field_res_better_zip_sort
@@ -61,9 +58,6 @@ msgid ""
 "not included, 1 = included. Delivery information with addresses (only "
 "postcode and streets) are published in the sort file."
 msgstr ""
-"Beschreibt, ob die Postleitzahl enthalten ist im «sort file»(MAT[CH]sort): 0"
-" = nicht enthalten, 1 = enthalten. Lieferinformation mit Adresse (nur "
-"Postleitzahl und Strasse) werden im sort file publiziert."
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,help:l10n_ch_zip.field_res_better_zip_post_delivery_through
@@ -79,19 +73,16 @@ msgid ""
 " 3 = Italian, 4 = Romansh. For multi-lingual localities, the main language "
 "is indicated."
 msgstr ""
-"Sprache (mehrheit) innerhalb einer Postleitzahlregion. 1=Deutsch, "
-"2=Französisch, 3=Italienisch, 4=Rätoromanisch. Für mehrsprachige Orte wird "
-"die Hauptsprache angegeben."
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_lang
 msgid "Language code"
-msgstr "Sprachcode"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_post_delivery_through
 msgid "Mail delivery by"
-msgstr "Postversand durch"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,help:l10n_ch_zip.field_res_better_zip_communitynumber_bfs
@@ -99,28 +90,26 @@ msgid ""
 "Numbering used by the Federal Statistical Office for municipalities in "
 "Switzerland and the Principality of Liechtenstein"
 msgstr ""
-"Nummerierung vom Bundesamt für Statistik für Ortschaften in der Schweiz und "
-"Fürstentum Liechtenstein."
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_zip_type
 msgid "Postcode type"
-msgstr "Art der Postleitzahl"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_sort
 msgid "Present in sort file"
-msgstr "In der Sortierungsdatei vorhanden"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,help:l10n_ch_zip.field_res_better_zip_onrp
 msgid "Primary Key"
-msgstr "Primärschlüssel"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_onrp
 msgid "Swiss Post classification no. (ONRP)"
-msgstr "Schweizerische Post klassifizierungsnummer (ONRP)"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_valid_from

--- a/l10n_ch_zip/i18n/fr.po
+++ b/l10n_ch_zip/i18n/fr.po
@@ -4,14 +4,13 @@
 # 
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
-# leemannd <denis.leemann@camptocamp.com>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-07 03:35+0000\n"
-"PO-Revision-Date: 2017-01-07 03:35+0000\n"
-"Last-Translator: leemannd <denis.leemann@camptocamp.com>, 2017\n"
+"POT-Creation-Date: 2017-12-01 21:23+0000\n"
+"PO-Revision-Date: 2017-12-01 21:23+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
 "Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,7 +21,7 @@ msgstr ""
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_active
 msgid "Active"
-msgstr "Actif"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,help:l10n_ch_zip.field_res_better_zip_lang2

--- a/l10n_ch_zip/i18n/it.po
+++ b/l10n_ch_zip/i18n/it.po
@@ -3,15 +3,15 @@
 # * l10n_ch_zip
 # 
 # Translators:
-# Stefano <stefano.sforzi@agilebg.com>, 2015
+# OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: l10n-switzerland (9.0)\n"
+"Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-16 01:38+0000\n"
-"PO-Revision-Date: 2016-03-14 15:17+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Italian (http://www.transifex.com/oca/OCA-l10n-switzerland-9-0/language/it/)\n"
+"POT-Creation-Date: 2017-12-01 21:23+0000\n"
+"PO-Revision-Date: 2017-12-01 21:23+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -21,7 +21,7 @@ msgstr ""
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_active
 msgid "Active"
-msgstr "Attivo"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,help:l10n_ch_zip.field_res_better_zip_lang2
@@ -82,14 +82,14 @@ msgstr ""
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_post_delivery_through
 msgid "Mail delivery by"
-msgstr "Posta invata da"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,help:l10n_ch_zip.field_res_better_zip_communitynumber_bfs
 msgid ""
 "Numbering used by the Federal Statistical Office for municipalities in "
 "Switzerland and the Principality of Liechtenstein"
-msgstr "Numerazione utilizzata dall'Ufficio Federale di Statistica per le municipalità Svizzere e del Principato del Liechtestein"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_zip_type
@@ -104,7 +104,7 @@ msgstr ""
 #. module: l10n_ch_zip
 #: model:ir.model.fields,help:l10n_ch_zip.field_res_better_zip_onrp
 msgid "Primary Key"
-msgstr "Chiave primaria"
+msgstr ""
 
 #. module: l10n_ch_zip
 #: model:ir.model.fields,field_description:l10n_ch_zip.field_res_better_zip_onrp

--- a/l10n_ch_zip/models/better_zip.py
+++ b/l10n_ch_zip/models/better_zip.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2011-2017 Camptocamp SA
 # Copyright 2014 Olivier Jossen (brain-tec AG)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/l10n_ch_zip/models/better_zip.py
+++ b/l10n_ch_zip/models/better_zip.py
@@ -37,7 +37,7 @@ class ResBetterZip(models.Model):
     )
     sort = fields.Boolean(
         string='Present in sort file',
-        help="Indicates if the postcode is included in the «sort file»"
+        help="Indicates if the postcode is included in the 'sort file'"
              "(MAT[CH]sort): 0 = not included, 1 = included. "
              "Delivery information with addresses (only postcode and "
              "streets) are published in the sort file.",

--- a/l10n_ch_zip/models/better_zip.py
+++ b/l10n_ch_zip/models/better_zip.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011-2017 Camptocamp SA
 # Copyright 2014 Olivier Jossen (brain-tec AG)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).


### PR DESCRIPTION
Error happening while installing as submodule on odoo.sh
l10n_ch_zip/models/better_zip.py on line 39, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details