### PR TITLE
Add sudo() when creating a temp country

### DIFF
--- a/l10n_ch_payment_slip/models/payment_slip.py
+++ b/l10n_ch_payment_slip/models/payment_slip.py
@@ -450,7 +450,7 @@ class PaymentSlip(models.Model):
         # use onchange to define our own temporary address format
         with self.env.do_in_onchange():
             # assign a fake country in case partner has no country set
-            com_partner.country_id = self.env['res.country'].new(
+            com_partner.country_id = self.env['res.country'].sudo().new(
                 {'address_format': bvr_address_format}
             )
             address_lines = com_partner._display_address(


### PR DESCRIPTION
Small PR to correct an issue : if a user with no creationrights on the "res.country" object prints a BVR, the zip and city will be inverted, as the default address format will be used.