### PR TITLE
[URGENT][FIX] account_statement_base_import: wrong import on camt.py

### DIFF
--- a/l10n_ch_account_statement_base_import/parsers/camt.py
+++ b/l10n_ch_account_statement_base_import/parsers/camt.py
@@ -19,7 +19,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from openerp.addons.account_bank_statement_import_camt.camt import CamtParser
+from openerp.addons.account_bank_statement_import_camt.models.parser import CamtParser
 
 
 class PFCamtParser(CamtParser):


### PR DESCRIPTION
This fix is needed because of this [commit](https://github.com/OCA/bank-statement-import/commit/b9e8796225bd2b8415b81bafbea70d19f168a744)