### PR TITLE
[10.0] l10n_ch_payment_slip: fix `_get_address_lines`

### DIFF
--- a/l10n_ch_payment_slip/README.rst
+++ b/l10n_ch_payment_slip/README.rst
@@ -77,6 +77,7 @@ Contributors
 * Paulius Sladkevičius <paulius@hbee.eu>
 * David Coninckx <dco@open-net.ch>
 * Akim Juillerat <akim.juillerat@camptocamp.com>
+* Simone Orsi <simone.orsi@camptocamp.com>
 
 Financial contributors
 ----------------------

--- a/l10n_ch_payment_slip/__manifest__.py
+++ b/l10n_ch_payment_slip/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Switzerland - Payment Slip (BVR/ESR)',
  'summary': 'Print ESR/BVR payment slip with your invoices',
- 'version': '10.0.1.1.2',
+ 'version': '10.0.1.1.3',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'category': 'Localization',
  'website': 'http://www.camptocamp.com',

--- a/l10n_ch_payment_slip/models/payment_slip.py
+++ b/l10n_ch_payment_slip/models/payment_slip.py
@@ -391,7 +391,7 @@ class PaymentSlip(models.Model):
                                        self.font_absolute_path()))
 
     @api.model
-    def _get_samll_text_font(self):
+    def _get_small_text_font(self):
         """Register a :py:class:`reportlab.pdfbase.ttfonts.TTFont`
         for recept reference
         :return: a :py:class:`FontMeta` with font name and size
@@ -808,7 +808,7 @@ class PaymentSlip(models.Model):
         print_settings = self._get_settings(report_name)
         self._register_fonts()
         default_font = self._get_text_font()
-        small_font = self._get_samll_text_font()
+        small_font = self._get_small_text_font()
         amount_font = self._get_amount_font()
         invoice = self.move_line_id.invoice_id
         scan_font = self._get_scan_line_text_font(company)

--- a/l10n_ch_payment_slip/models/payment_slip.py
+++ b/l10n_ch_payment_slip/models/payment_slip.py
@@ -12,7 +12,7 @@ from reportlab.pdfgen.canvas import Canvas
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.lib.units import inch
-from odoo import models, fields, api, _, exceptions
+from odoo import models, fields, api, _, exceptions, tools
 from odoo.report import report_sxw
 from odoo.modules import get_module_resource
 from odoo.tools.misc import mod10r
@@ -443,18 +443,26 @@ class PaymentSlip(models.Model):
                         size=size)
 
     @api.model
-    def _get_address_lines(self, com_partner):
+    @tools.ormcache_context('self._uid', 'com_partner_id', keys=('lang',))
+    def _get_address_lines(self, com_partner_id):
         bvr_address_format = (
             self.env['ir.config_parameter'].get_param('bvr.address.format') or
             ADDR_FORMAT)
+        # clone the partner to not affect real partner
+        com_partner = self.env['res.partner'].browse(com_partner_id)
+        partner = self.env['res.partner'].new(com_partner.copy_data()[0])
         # use onchange to define our own temporary address format
         with self.env.do_in_onchange():
             # assign a fake country in case partner has no country set
-            com_partner.country_id = self.env['res.country'].new()
-            com_partner.country_id.address_format = bvr_address_format
-            address_lines = com_partner._display_address(
+            # NOTE: creating the country BEFORE assigning the format to it
+            # is mandatory. If you create and assign the value at the same time
+            # `address_format` won't be populated properly!
+            partner.country_id = self.env['res.country'].sudo().new()
+            partner.country_id.update({
+                'address_format': bvr_address_format
+            })
+            address_lines = partner._display_address(
                 without_company=True).split("\n")
-        com_partner.invalidate_cache()
         return address_lines
 
     @api.model
@@ -509,7 +517,7 @@ class PaymentSlip(models.Model):
         :type com_partner: :py:class:`openerp.models.Model`
 
         """
-        address_lines = self._get_address_lines(com_partner)
+        address_lines = self._get_address_lines(com_partner.id)
 
         font_size, cutoff_length = self._get_address_font_size(
             font.size, address_lines, com_partner)

--- a/l10n_ch_payment_slip/tests/test_payment_slip.py
+++ b/l10n_ch_payment_slip/tests/test_payment_slip.py
@@ -181,7 +181,7 @@ class TestPaymentSlip(test_common.TransactionCase):
             [('move_line_id', '=', line.id)]
         )
         com_partner = slip.get_comm_partner()
-        address_lines = slip._get_address_lines(com_partner)
+        address_lines = slip._get_address_lines(com_partner.id)
         self.assertEqual(
             address_lines,
             [u'93, Press Avenue', u'', u'73377 Le Bourget du Lac']
@@ -196,7 +196,7 @@ class TestPaymentSlip(test_common.TransactionCase):
         )
         com_partner = slip.get_comm_partner()
         demo_user = self.env.ref('base.user_demo')
-        address_lines = slip.sudo(demo_user)._get_address_lines(com_partner)
+        address_lines = slip.sudo(demo_user)._get_address_lines(com_partner.id)
         self.assertEqual(
             address_lines,
             [u'93, Press Avenue', u'', u'73377 Le Bourget du Lac']
@@ -211,7 +211,7 @@ class TestPaymentSlip(test_common.TransactionCase):
         )
         com_partner = slip.get_comm_partner()
         com_partner.country_id = False
-        address_lines = slip._get_address_lines(com_partner)
+        address_lines = slip._get_address_lines(com_partner.id)
         self.assertEqual(
             address_lines,
             [u'93, Press Avenue', u'', u'73377 Le Bourget du Lac']
@@ -233,7 +233,7 @@ class TestPaymentSlip(test_common.TransactionCase):
         )
         com_partner = slip.get_comm_partner()
         com_partner.country_id = False
-        address_lines = slip._get_address_lines(com_partner)
+        address_lines = slip._get_address_lines(com_partner.id)
         self.assertEqual(
             address_lines,
             [u'93, Press Avenue', u'73377 Le Bourget du Lac']
@@ -247,7 +247,7 @@ class TestPaymentSlip(test_common.TransactionCase):
             [('move_line_id', '=', line.id)]
         )
         com_partner = slip.get_comm_partner()
-        address_lines = slip._get_address_lines(com_partner)
+        address_lines = slip._get_address_lines(com_partner.id)
         f_size = 11
 
         len_tests = [


### PR DESCRIPTION
l10n_ch_payment_slip: fix `_get_address_lines`
    
    `payment_slip._get_address_lines` computes the address of the partner.
    
    This is done in an onchange context whereas the changes where not isolated
    and they were propagated to the real partner
    via all the onchanges related to it.
    
    We spotted the issue on the mail compose wizard
    whereas the chain of onchanges was wiping all the default values.
    
    With this change we:
    
    * isolate the partner w/ a fake record
    * additionally we cache the result per each partner
      since the function is called several times
