### PR TITLE
[10.0][FIX] Fix pain_credit_transfer with multiple currencies

### DIFF
--- a/l10n_ch_pain_credit_transfer/models/__init__.py
+++ b/l10n_ch_pain_credit_transfer/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import account_payment_method
+from . import account_payment_order

--- a/l10n_ch_pain_credit_transfer/models/account_payment_order.py
+++ b/l10n_ch_pain_credit_transfer/models/account_payment_order.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# copyright 2018 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, api
+
+
+class AccountPaymentOrder(models.Model):
+    _inherit = 'account.payment.order'
+
+    @api.model
+    def _get_line_key(self, line):
+        return super(AccountPaymentOrder, self)._get_line_key(line) + (
+            line.currency_id.name,
+        )
+
+    @api.model
+    def generate_start_payment_info_block(
+            self, parent_node, payment_info_ident,
+            priority, local_instrument, category_purpose, sequence_type,
+            requested_date, eval_ctx, gen_args):
+        return super(AccountPaymentOrder,
+                     self).generate_start_payment_info_block(
+            parent_node, "self.name + '-' "
+                         "+ requested_date.replace('-', '') + '-' "
+                         "+ priority + '-' "
+                         "+ optional_args[0] + '-' "
+                         "+ local_instrument + '-' "
+                         "+ category_purpose",
+            priority, local_instrument, category_purpose, sequence_type,
+            requested_date, eval_ctx, gen_args)

--- a/l10n_ch_pain_credit_transfer/models/account_payment_order.py
+++ b/l10n_ch_pain_credit_transfer/models/account_payment_order.py
@@ -19,13 +19,18 @@ class AccountPaymentOrder(models.Model):
             self, parent_node, payment_info_ident,
             priority, local_instrument, category_purpose, sequence_type,
             requested_date, eval_ctx, gen_args):
+        """ Replace the original Payment Identification (unique per file)
+            in order to discriminate the records by currency"""
+        payment_info_ident = (
+            "self.name + '-' "
+            "+ requested_date.replace('-', '') + '-' "
+            "+ priority + '-' "
+            "+ optional_args[0] + '-' "
+            "+ local_instrument + '-' "
+            "+ category_purpose"
+        )
         return super(AccountPaymentOrder,
                      self).generate_start_payment_info_block(
-            parent_node, "self.name + '-' "
-                         "+ requested_date.replace('-', '') + '-' "
-                         "+ priority + '-' "
-                         "+ optional_args[0] + '-' "
-                         "+ local_instrument + '-' "
-                         "+ category_purpose",
+            parent_node, payment_info_ident,
             priority, local_instrument, category_purpose, sequence_type,
             requested_date, eval_ctx, gen_args)


### PR DESCRIPTION
Override base add-on to comply with Swiss Payment Standards : it is not allowed to have payments with different currencies in the same B-Level block.

Needs:
- [x] https://github.com/OCA/bank-payment/pull/462 to work