### PR TITLE
[11.0][FIX] _compute_acc_type failing on recordsets

### DIFF
--- a/l10n_ch_base_bank/models/bank.py
+++ b/l10n_ch_base_bank/models/bank.py
@@ -191,7 +191,7 @@ class ResPartnerBank(models.Model, BankCommon):
         todo = self.env['res.partner.bank']
         for rec in self:
             if (rec.acc_number and
-                    rec.is_swiss_postal_num(self.acc_number)):
+                    rec.is_swiss_postal_num(rec.acc_number)):
                 rec.acc_type = 'postal'
                 continue
             todo |= rec


### PR DESCRIPTION
As the method is multi, it shouldn't use self to get record fields.
@yvaucher 