### PR TITLE
[FIX][7.0] Allow manual payment creation without invoice

### DIFF
--- a/l10n_ch_sepa/__openerp__.py
+++ b/l10n_ch_sepa/__openerp__.py
@@ -22,7 +22,7 @@
 {
     "name": "Switzerland - SEPA Electronic Payment File",
     "summary": "Generate pain.001 Credit Transfert Files for your payments",
-    "version": "1.0",
+    "version": "1.1",
     "category": "Finance",
     "description": """
 Swiss electronic payment (SEPA)

--- a/l10n_ch_sepa/l10n_ch/template/pain.001.001.03.ch.02.xml.mako
+++ b/l10n_ch_sepa/l10n_ch/template/pain.001.001.03.ch.02.xml.mako
@@ -20,9 +20,8 @@
 </%doc>\
    <%
    line=sepa_context['line']
-   invoice = line.move_line_id.invoice
    %>
-   % if not invoice.partner_bank_id.state == 'bvr':
+   % if not line.bank_id.state == 'bvr':
     ${parent.CdtrAgt()}
    % endif
 </%block>
@@ -45,9 +44,8 @@
 </%doc>\
    <%
    line=sepa_context['line']
-   invoice = line.move_line_id.invoice
    %>
-   % if invoice.partner_bank_id.state == 'bvr':
+   % if line.bank_id.state == 'bvr':
           <PmtTpInf>
               <LclInstrm>
                 <Prtry>CH01</Prtry>
@@ -59,13 +57,12 @@
 <%block name="RmtInf">
    <%
    line=sepa_context['line']
-   invoice = line.move_line_id.invoice
    %>
-   % if invoice.reference_type == 'bvr':
+   % if line.bank_id.state == 'bvr':
           <RmtInf>
             <Strd>
               <CdtrRefInf>
-                <Ref>${invoice.reference}</Ref>
+                <Ref>${line.communication}</Ref>
               </CdtrRefInf>
             </Strd>
           </RmtInf>


### PR DESCRIPTION
The actual implementation was taking informations from invoice.
This PR aims to take these informations where they are setted, even if you have no invoice.