### PR TITLE
[11.0][FIX] l10n_ch_pain_base - fix error message

### DIFF
--- a/l10n_ch_pain_base/models/account_payment_order.py
+++ b/l10n_ch_pain_base/models/account_payment_order.py
@@ -89,7 +89,7 @@ class AccountPaymentOrder(models.Model):
             if not partner_bank.ccp:
                 raise UserError(_(
                     "The field 'CCP/CP-Konto' is not set on the bank "
-                    "account '%s'.") % partner_bank.name)
+                    "account '%s'.") % partner_bank.bank_id.name)
             party_account = etree.SubElement(
                 parent_node, '%sAcct' % party_type)
             party_account_id = etree.SubElement(party_account, 'Id')

--- a/l10n_ch_pain_base/models/account_payment_order.py
+++ b/l10n_ch_pain_base/models/account_payment_order.py
@@ -89,7 +89,7 @@ class AccountPaymentOrder(models.Model):
             if not partner_bank.ccp:
                 raise UserError(_(
                     "The field 'CCP/CP-Konto' is not set on the bank "
-                    "account '%s'.") % partner_bank.bank_id.name)
+                    "account '%s'.") % partner_bank.acc_number)
             party_account = etree.SubElement(
                 parent_node, '%sAcct' % party_type)
             party_account_id = etree.SubElement(party_account, 'Id')


### PR DESCRIPTION
Fix of the field used on the UsserError message when no CCP account is set.
The field 'partner_bank.name' doesn't exist, the corresponding field is 'partner_bank.bank_id.name'