### PR TITLE
[FIX] make only 1 payment

### DIFF
--- a/l10n_ch_sepa/base_sepa/base_template/pain.001.001.03.xml.mako
+++ b/l10n_ch_sepa/base_sepa/base_template/pain.001.001.03.xml.mako
@@ -25,30 +25,36 @@
   in sub blocks and inheritages. Because, for now, only unamed
   blocks and def in mako can use a local for loop variable.
 </%doc>\
-% for line in order.line_ids:
-  <% sepa_context['line'] = line %>\
   <%block name="PmtInf">\
-    <%
-    line = sepa_context['line']
-    today = thetime.strftime("%Y-%m-%d")
-    %>
+        <%
+        today = thetime.strftime("%Y-%m-%d")
+        %>
       <PmtInf>
-        <PmtInfId>${line.name}</PmtInfId>
+        <PmtInfId>${order.reference}</PmtInfId>
         <PmtMtd>TRF</PmtMtd>
-        <BtchBookg>false</BtchBookg>
-        <ReqdExctnDt>${line.date > today and line.date or today}</ReqdExctnDt>
+        <BtchBookg>true</BtchBookg>
+        <ReqdExctnDt>${order.date_scheduled > today and order.date_scheduled or today}</ReqdExctnDt>
         <Dbtr>
           <Nm>${order.user_id.company_id.name}</Nm>\
           ${self.address(order.user_id.company_id.partner_id)}\
         </Dbtr>
         <DbtrAcct>\
           ${self.acc_id(order.mode.bank_id)}\
+         <Tp>
+            <Prtry>CWD</Prtry>
+         </Tp>\
+
         </DbtrAcct>
         <DbtrAgt>
           <FinInstnId>
             <BIC>${order.mode.bank_id.bank.bic or order.mode.bank_id.bank_bic}</BIC>
           </FinInstnId>
         </DbtrAgt>
+ % for line in order.line_ids:
+        <% sepa_context['line'] = line %>
+        <%
+        line = sepa_context['line']
+        %>
         <CdtTrfTxInf>
           <PmtId>
             <EndToEndId>${line.name}</EndToEndId>
@@ -79,9 +85,9 @@
           </CdtrAcct>\
           <%block name="RmtInf"/>
         </CdtTrfTxInf>
+% endfor
       </PmtInf>\
   </%block>
-% endfor
 \
   </CstmrCdtTrfInitn>
 </Document>

--- a/l10n_ch_sepa/base_sepa/base_template/pain.001.001.03.xml.mako
+++ b/l10n_ch_sepa/base_sepa/base_template/pain.001.001.03.xml.mako
@@ -57,6 +57,7 @@
         %>
         <CdtTrfTxInf>
           <PmtId>
+            <InstrId>${line.name}</InstrId>
             <EndToEndId>${line.name}</EndToEndId>
           </PmtId>
           <%block name="PmtTpInf"/>


### PR DESCRIPTION
This module previously create one payment operation for each line
it generate a lot of document.

I have also a add the tag InstrID, it's optional for SIX payment validation tools, but required by most cantonal banks
