### PR TITLE
[11.0][FIX] res.partner.bank: retrieve partner name from context on creation

### DIFF
--- a/l10n_ch_base_bank/__manifest__.py
+++ b/l10n_ch_base_bank/__manifest__.py
@@ -3,7 +3,7 @@
 
 {'name': 'Switzerland - Bank type',
  'summary': 'Types and number validation for swiss electronic pmnt. DTA, ESR',
- 'version': '11.0.1.1.0',
+ 'version': '11.0.1.1.1',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'category': 'Localization',
  'website': 'http://www.camptocamp.com',

--- a/l10n_ch_base_bank/models/bank.py
+++ b/l10n_ch_base_bank/models/bank.py
@@ -239,11 +239,16 @@ class ResPartnerBank(models.Model, BankCommon):
     def _get_acc_name(self):
         """ Return an account name for a bank account
         to use with a ccp for ISR.
-        This method make sure to generate a unique name
+        This method makes sure to generate a unique name
         """
+
         part_name = self.partner_id.name
+        if not part_name and self.env.context.get('default_partner_id'):
+            partner_id = self.env.context.get('default_partner_id')
+            part_name = self.env['res.partner'].browse(partner_id)[0].name
+
         if part_name:
-            acc_name = _("Bank/CCP {}").format(self.partner_id.name)
+            acc_name = _("Bank/CCP {}").format(part_name)
         else:
             acc_name = _("Bank/CCP Undefined")
 


### PR DESCRIPTION
This commit fixes a minor issue where creating a `res.partner.bank` instance from a partner form (_Accounting_ > _Master Data_ > _Customers/Vendors_ > _Sales & Purchases_ > _Bank accounts_  menu entries) and entering a CCP code (e.g. _46-110-7_) would automatically generate an account name: "_Bank/CCP Undefined_" when we would expect the related partner name to be present.

As the related partner ID is available in the context, we retrieve it from there.