### PR TITLE
wrong field name

### DIFF
--- a/l10n_ch_pain_base/models/account_payment_order.py
+++ b/l10n_ch_pain_base/models/account_payment_order.py
@@ -90,7 +90,7 @@ class AccountPaymentOrder(models.Model):
             if not partner_bank.ccp:
                 raise UserError(_(
                     "The field 'CCP/CP-Konto' is not set on the bank "
-                    "account '%s'.") % partner_bank.name)
+                    "account '%s'.") % partner_bank.bank_name)
             party_account = etree.SubElement(
                 parent_node, '%sAcct' % party_type)
             party_account_id = etree.SubElement(party_account, 'Id')


### PR DESCRIPTION
It seems that the field "name" doesn't exists in res.partner.bank model. It's "bank_name" instead.