### PR TITLE
[10.0] l10n_ch_scan_bvr - Support of Postal BVR

### DIFF
--- a/l10n_ch_scan_bvr/wizard/scan_bvr.py
+++ b/l10n_ch_scan_bvr/wizard/scan_bvr.py
@@ -353,8 +353,9 @@ class ScanBvr(models.TransientModel):
             domain = [('ccp', '=', data['bvr_struct']['beneficiaire'])]
         else:
             domain = \
-                [('ccp', '=', data['bvr_struct']['beneficiaire']),
-                 ('bvr_adherent_num', '=', data['bvr_struct']['bvrnumber'])]
+                [('ccp', '=', data['bvr_struct']['beneficiaire']), '|',
+                 ('bvr_adherent_num', '=', data['bvr_struct']['bvrnumber']),
+                 ('bvr_adherent_num', '=', False)]
         partner_bank = partner_bank_model.search(domain, limit=1)
         # We will need to know if we need to create invoice line
         if partner_bank:

--- a/l10n_ch_scan_bvr/wizard/scan_bvr.py
+++ b/l10n_ch_scan_bvr/wizard/scan_bvr.py
@@ -352,15 +352,15 @@ class ScanBvr(models.TransientModel):
         domain = [('ccp', '=', data['bvr_struct']['beneficiaire'])]
         partner_banks_count = partner_bank_model.search_count(domain)
         if partner_banks_count > 1:
-            #We have found many banks with same ccp
+            # We have found many banks with same ccp
             if data['bvr_struct']['domain'] != 'name':
-                #We have a bvr number and search for ccp/bvrnumber pair
+                # We have a bvr number and search for ccp/bvrnumber pair
                 domain = \
                     [('ccp', '=', data['bvr_struct']['beneficiaire']),
                      ('bvr_adherent_num', '=', data['bvr_struct']['bvrnumber'])]
             partner_bank = partner_bank_model.search(domain, limit=1)
         elif partner_banks_count == 1:
-            #We have found one bank we this ccp, take it
+            # We have found one bank we this ccp, take it
             partner_bank = partner_bank_model.search(domain)
         # We will need to know if we need to create invoice line
         if partner_bank:


### PR DESCRIPTION
It's possible to have BVR for Postal accounts that are type 01 but with 53 positions.
Now your are getting the bvrnumber (bvr adherent number) and searching for it but they have no bvr adherent number, only the CCP.
By the way the bvrnumber for those BVR is not equal to '000000'.
Then if there is something in the bvrnumber, you should search for CCP/adherent = bvrnumber or CCP only (adherent = False)