### PR TITLE
[11.0] Fix dependency to mis_builder_budget to remove runbot warning

### DIFF
--- a/l10n_ch_mis_reports/__manifest__.py
+++ b/l10n_ch_mis_reports/__manifest__.py
@@ -5,14 +5,14 @@
 {
     'name': 'Switzerland - MIS reports',
     'summary': 'Specific MIS reports for switzerland localization',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'author': "Camptocamp,Odoo Community Association (OCA)",
     'category': 'Localization',
     'website': 'https://github.com/OCA/l10n-switzerland',
     'license': 'AGPL-3',
     'depends': [
         'l10n_ch',
-        'mis_builder',
+        'mis_builder_budget',
         'l10n_ch_account_tags',
     ],
     'data': [


### PR DESCRIPTION
Runbot states :
```
2018-09-05 12:05:12,983 166 WARNING openerp_test odoo.models: mis.report.kpi.create() includes unknown fields: budgetable
```
Field is declared in mis_builder_budget :

https://github.com/OCA/mis-builder/blob/10.0/mis_builder_budget/models/mis_report_kpi.py#L12