### PR TITLE
[9.0][IMP] l10n_ch_bank_statement_import_postfinance add date from PF into the bank statement

### DIFF
--- a/l10n_ch_bank_statement_import_postfinance/models/postfinance_file_parser.py
+++ b/l10n_ch_bank_statement_import_postfinance/models/postfinance_file_parser.py
@@ -74,6 +74,9 @@ class XMLPFParser(models.AbstractModel):
                 '//ns:Bal[1]/ns:Amt/@Ccy', namespaces={'ns': ns})
             if currency_node and len(currency_node) == 1:
                 result['currency'] = currency_node[0]
+        if not result.get('date'):
+            self.add_value_from_node(
+                ns, node, '//ns:Stmt/ns:CreDtTm', result, 'date')
         return result
 
     def _check_postfinance_attachments(self, data_file):

--- a/l10n_ch_bank_statement_import_postfinance/static/src/js/account_statement_reconciliation.js
+++ b/l10n_ch_bank_statement_import_postfinance/static/src/js/account_statement_reconciliation.js
@@ -9,7 +9,7 @@ odoo.define('l10n_ch_bank_statement_import_postfinance.reconciliation', function
 
     // Extend the class written in module account (bank statement view)
     reconciliation.bankStatementReconciliationLine.include({
-        decorateStatementLine: function(line){
+        decorateStatementLine: function (line) {
             this._super(line);
             line.i_popover = QWeb.render("bank_statement_reconciliation_line_image", {line: line});
         },

--- a/l10n_ch_bank_statement_import_postfinance/tests/test_postfinance_xml.py
+++ b/l10n_ch_bank_statement_import_postfinance/tests/test_postfinance_xml.py
@@ -90,7 +90,6 @@ class PFXMLParserTest(common.TransactionCase):
             'file_ref': '20160414001203000300003',
             'amount': 50.0,
             'date': '2017-03-30',
-            'value_date': '2017-03-30',
             'ref': 'CLXPMZW000000004'
         }
         parsed_transaction = statement['transactions'][0]
@@ -111,6 +110,12 @@ class PostFinanceImportTest(common.TransactionCase):
 
     def setUp(self):
         super(PostFinanceImportTest, self).setUp()
+        self.currency = self.env.ref('base.CHF')
+        self.currency.active = True
+        company_a = self.env.ref('base.main_company')
+        self.cr.execute('UPDATE res_company '
+                        'SET currency_id = %s '
+                        'WHERE id = %s', [self.currency.id, company_a.id])
         bank = self.env['res.partner.bank'].create({
             'acc_number': 'CH0309000000250090342',
             'partner_id': self.env.ref('base.main_partner').id,
@@ -123,11 +128,6 @@ class PostFinanceImportTest(common.TransactionCase):
             'type': 'bank',
             'bank_account_id': bank.id,
         })
-        self.company_a = self.env.ref('base.main_company')
-        currency = self.env.ref('base.CHF')
-        self.company_a.write(
-            {'currency_id': currency.id}
-        )
 
     def test_postfinance_xml_import(self):
         """Test if postfinance statement is correct"""

--- a/l10n_ch_dta/tests/test_dta.py
+++ b/l10n_ch_dta/tests/test_dta.py
@@ -33,6 +33,9 @@ class TestDTA(AccountingTestCase):
         self.invoice_model = self.env['account.invoice']
         self.invoice_line_model = self.env['account.invoice.line']
         company = self.env.ref('base.main_company')
+        eur_currency = self.env.ref('base.EUR')
+        eur_currency.active = True
+        company.currency_id = eur_currency.id
         self.partner_agrolait = self.env.ref('base.res_partner_2')
         self.partner_c2c = self.env.ref('base.res_partner_12')
         self.account_expense = self.account_model.search([(
@@ -66,8 +69,6 @@ class TestDTA(AccountingTestCase):
             'fixed_journal_id': self.bank_journal.id,
         })
 
-        eur_currency_id = self.env.ref('base.EUR').id
-        company.currency_id = eur_currency_id
         invoice1 = self.create_invoice(
             self.partner_agrolait.id,
             'account_payment_mode.res_partner_2_iban', 42.0, 'F1341')

--- a/l10n_ch_lsv_dd/test/lsv-dd-test.yml
+++ b/l10n_ch_lsv_dd/test/lsv-dd-test.yml
@@ -192,7 +192,6 @@
     company_id: base.main_company
     journal_id: !ref {model: account.journal, search: "[('type','=','bank')]"}
     currency_id: base.CHF
-    account_id: !ref {model: account.account, search: "[('code','=','1100')]"}
     type : out_invoice
     partner_id: customer
     date_invoice: !eval "'%s-01-02' %(datetime.now().year)"
@@ -205,7 +204,7 @@
     company_id: base.main_company
     journal_id: !ref {model: account.journal, search: "[('type','=','bank')]"}
     currency_id: base.CHF
-    account_id: !ref {model: account.account, search: "[('code','=','1100')]"}
+    account_id: a_recv
     type : out_invoice
     partner_id: customer
     date_invoice: !eval "'%s-01-02' %(datetime.now().year)"
@@ -218,7 +217,7 @@
     company_id: base.main_company
     journal_id: !ref {model: account.journal, search: "[('type','=','bank')]"}
     currency_id: base.CHF
-    account_id: !ref {model: account.account, search: "[('code','=','1100')]"}
+    account_id: a_recv
     type : out_invoice
     partner_id: customer
     date_invoice: !eval "'%s-01-02' %(datetime.now().year)"


### PR DESCRIPTION
The date from the PF statement is lost, as the file format diverges from the default one. This commit parses the correct date into account.bank.statement table. 