### PR TITLE
Error when using BVR in attachment

### DIFF
--- a/l10n_ch_payment_slip/report/report.py
+++ b/l10n_ch_payment_slip/report/report.py
@@ -81,6 +81,7 @@ class Report(models.Model):
                             doc.invoice_id.id),
                         'res_model': save_in_attachment.get('model'),
                         'res_id': doc.invoice_id.id,
+                        'type':'binary'
                     }
                     try:
                         self.env['ir.attachment'].create(attachment)


### PR DESCRIPTION
When you are on an invoice, you might have and default value for the context of the action with {'default_type':'out_invoice'}.
This default value will be passed to the context of the ir.attachment and there is a field "type" in the attachment which allows "url" and "binary" as values. Then it will throw an error
>UserError: (Wrong value for ir.attachment.type: 'out_invoice'
We can force the type to be 'binary'