### PR TITLE
[9.0][IMP] l10n_ch_bank_statement_import_postfinance add date from PF camt file into the bank statement

### DIFF
--- a/l10n_ch_bank_statement_import_postfinance/models/postfinance_file_parser.py
+++ b/l10n_ch_bank_statement_import_postfinance/models/postfinance_file_parser.py
@@ -74,6 +74,9 @@ class XMLPFParser(models.AbstractModel):
                 '//ns:Bal[1]/ns:Amt/@Ccy', namespaces={'ns': ns})
             if currency_node and len(currency_node) == 1:
                 result['currency'] = currency_node[0]
+        if not result.get('date'):
+            self.add_value_from_node(
+                ns, node, '//ns:Stmt/ns:CreDtTm', result, 'date')
         return result
 
     def _check_postfinance_attachments(self, data_file):

--- a/l10n_ch_bank_statement_import_postfinance/static/src/js/account_statement_reconciliation.js
+++ b/l10n_ch_bank_statement_import_postfinance/static/src/js/account_statement_reconciliation.js
@@ -9,9 +9,10 @@ odoo.define('l10n_ch_bank_statement_import_postfinance.reconciliation', function
 
     // Extend the class written in module account (bank statement view)
     reconciliation.bankStatementReconciliationLine.include({
-        decorateStatementLine: function(line){
+        decorateStatementLine: function (line) {
             this._super(line);
-            line.i_popover = QWeb.render("bank_statement_reconciliation_line_image", {line: line});
+            line.i_popover = QWeb.render(
+                "bank_statement_reconciliation_line_image", {line: line});
         },
     });
 });

--- a/l10n_ch_bank_statement_import_postfinance/tests/test_postfinance_xml.py
+++ b/l10n_ch_bank_statement_import_postfinance/tests/test_postfinance_xml.py
@@ -90,7 +90,6 @@ class PFXMLParserTest(common.TransactionCase):
             'file_ref': '20160414001203000300003',
             'amount': 50.0,
             'date': '2017-03-30',
-            'value_date': '2017-03-30',
             'ref': 'CLXPMZW000000004'
         }
         parsed_transaction = statement['transactions'][0]
@@ -111,6 +110,12 @@ class PostFinanceImportTest(common.TransactionCase):
 
     def setUp(self):
         super(PostFinanceImportTest, self).setUp()
+        self.currency = self.env.ref('base.CHF')
+        self.currency.active = True
+        company_a = self.env.ref('base.main_company')
+        self.cr.execute('UPDATE res_company '
+                        'SET currency_id = %s '
+                        'WHERE id = %s', [self.currency.id, company_a.id])
         bank = self.env['res.partner.bank'].create({
             'acc_number': 'CH0309000000250090342',
             'partner_id': self.env.ref('base.main_partner').id,
@@ -123,11 +128,6 @@ class PostFinanceImportTest(common.TransactionCase):
             'type': 'bank',
             'bank_account_id': bank.id,
         })
-        self.company_a = self.env.ref('base.main_company')
-        currency = self.env.ref('base.CHF')
-        self.company_a.write(
-            {'currency_id': currency.id}
-        )
 
     def test_postfinance_xml_import(self):
         """Test if postfinance statement is correct"""

--- a/l10n_ch_dta/tests/test_dta.py
+++ b/l10n_ch_dta/tests/test_dta.py
@@ -32,7 +32,12 @@ class TestDTA(AccountingTestCase):
         self.attachment_model = self.env['ir.attachment']
         self.invoice_model = self.env['account.invoice']
         self.invoice_line_model = self.env['account.invoice.line']
+        self.eur_currency = self.env.ref('base.EUR')
+        self.eur_currency.active = True
         company = self.env.ref('base.main_company')
+        self.cr.execute('UPDATE res_company '
+                        'SET currency_id = %s '
+                        'WHERE id = %s', [self.eur_currency.id, company.id])
         self.partner_agrolait = self.env.ref('base.res_partner_2')
         self.partner_c2c = self.env.ref('base.res_partner_12')
         self.account_expense = self.account_model.search([(
@@ -66,8 +71,6 @@ class TestDTA(AccountingTestCase):
             'fixed_journal_id': self.bank_journal.id,
         })
 
-        eur_currency_id = self.env.ref('base.EUR').id
-        company.currency_id = eur_currency_id
         invoice1 = self.create_invoice(
             self.partner_agrolait.id,
             'account_payment_mode.res_partner_2_iban', 42.0, 'F1341')
@@ -100,7 +103,8 @@ class TestDTA(AccountingTestCase):
         self.assertEquals(len(pay_lines), 3)
         agrolait_pay_line1 = pay_lines[0]
         accpre = self.env['decimal.precision'].precision_get('Account')
-        self.assertEquals(agrolait_pay_line1.currency_id.id, eur_currency_id)
+        self.assertEquals(
+            agrolait_pay_line1.currency_id.id, self.eur_currency.id)
         self.assertEquals(
             agrolait_pay_line1.partner_bank_id, invoice1.partner_bank_id)
         self.assertEquals(float_compare(
@@ -114,7 +118,8 @@ class TestDTA(AccountingTestCase):
             ('partner_id', '=', self.partner_agrolait.id)])
         self.assertEquals(len(bank_lines), 1)
         agrolait_bank_line = bank_lines[0]
-        self.assertEquals(agrolait_bank_line.currency_id.id, eur_currency_id)
+        self.assertEquals(
+            agrolait_bank_line.currency_id.id, self.eur_currency.id)
         self.assertEquals(float_compare(
             agrolait_bank_line.amount_currency, 49.0, precision_digits=accpre),
             0)

--- a/l10n_ch_lsv_dd/__init__.py
+++ b/l10n_ch_lsv_dd/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Swiss localization Direct Debit module for Odoo

--- a/l10n_ch_lsv_dd/__openerp__.py
+++ b/l10n_ch_lsv_dd/__openerp__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Swiss localization Direct Debit module for Odoo

--- a/l10n_ch_lsv_dd/models/__init__.py
+++ b/l10n_ch_lsv_dd/models/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Swiss localization Direct Debit module for Odoo

--- a/l10n_ch_lsv_dd/models/account_payment_method.py
+++ b/l10n_ch_lsv_dd/models/account_payment_method.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Swiss localization Direct Debit module for OpenERP

--- a/l10n_ch_lsv_dd/models/account_payment_order.py
+++ b/l10n_ch_lsv_dd/models/account_payment_order.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Swiss localization Direct Debit module for OpenERP

--- a/l10n_ch_lsv_dd/models/bank.py
+++ b/l10n_ch_lsv_dd/models/bank.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Swiss localization Direct Debit module for OpenERP

--- a/l10n_ch_lsv_dd/models/banking_export_ch_dd.py
+++ b/l10n_ch_lsv_dd/models/banking_export_ch_dd.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Swiss localization Direct Debit module for OpenERP

--- a/l10n_ch_lsv_dd/models/invoice.py
+++ b/l10n_ch_lsv_dd/models/invoice.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Swiss localization Direct Debit module for OpenERP

--- a/l10n_ch_lsv_dd/models/move_line.py
+++ b/l10n_ch_lsv_dd/models/move_line.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Swiss localization Direct Debit module for OpenERP

--- a/l10n_ch_lsv_dd/security/ir.model.access.csv
+++ b/l10n_ch_lsv_dd/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
-"access_ch_dd_export","Full access on banking.export.ch.dd","model_banking_export_ch_dd","base.group_sale_manager",1,1,1,1
+"access_ch_dd_export_manager","Full access on banking.export.ch.dd","model_banking_export_ch_dd","base.group_sale_manager",1,1,1,1
 "access_ch_dd_export","Full access on banking.export.ch.dd","model_banking_export_ch_dd","base.group_sale_salesman",1,1,1,1

--- a/l10n_ch_lsv_dd/test/lsv-dd-test.yml
+++ b/l10n_ch_lsv_dd/test/lsv-dd-test.yml
@@ -95,6 +95,7 @@
     partner_id: base.main_partner
     bank_id: bank_ubs
     lsv_identifier: 'AAAAA'
+    currency_id: 'base.CHF'
 -
   We need a company bvr account with a dd identifier (account which will be credited)
 -
@@ -104,6 +105,7 @@
     partner_id: base.main_partner
     bank_id: bank_post
     post_dd_identifier: '123457'
+    currency_id: 'base.CHF'
 -
   We need a company bvr account with a dd identifier for the XML-DD (account which will be credited)
 -
@@ -113,6 +115,7 @@
     partner_id: base.main_partner
     bank_id: bank_post
     post_dd_identifier: '123457'
+    currency_id: 'base.CHF'
 
 -
   We create a journal for LSV.
@@ -192,7 +195,6 @@
     company_id: base.main_company
     journal_id: !ref {model: account.journal, search: "[('type','=','bank')]"}
     currency_id: base.CHF
-    account_id: !ref {model: account.account, search: "[('code','=','1100')]"}
     type : out_invoice
     partner_id: customer
     date_invoice: !eval "'%s-01-02' %(datetime.now().year)"
@@ -205,7 +207,6 @@
     company_id: base.main_company
     journal_id: !ref {model: account.journal, search: "[('type','=','bank')]"}
     currency_id: base.CHF
-    account_id: !ref {model: account.account, search: "[('code','=','1100')]"}
     type : out_invoice
     partner_id: customer
     date_invoice: !eval "'%s-01-02' %(datetime.now().year)"
@@ -218,7 +219,6 @@
     company_id: base.main_company
     journal_id: !ref {model: account.journal, search: "[('type','=','bank')]"}
     currency_id: base.CHF
-    account_id: !ref {model: account.account, search: "[('code','=','1100')]"}
     type : out_invoice
     partner_id: customer
     date_invoice: !eval "'%s-01-02' %(datetime.now().year)"
@@ -229,7 +229,7 @@
   I add an invoice line to the invoice for LSV.
 -
   !record {model: account.invoice.line, id: lsv_invoice_line, view: False}:
-    account_id: !ref {model: account.account, search: "[('code','=','3200')]"}
+    account_id: !ref {model: account.account, search: "[('internal_type','=','receivable')]"}
     name: '[BASICCOMP] Basic Computer'
     price_unit: 700.0
     quantity: 10.0
@@ -239,7 +239,7 @@
   I add an invoice line to the invoice for DD.
 -
   !record {model: account.invoice.line, id: dd_invoice_line, view: False}:
-    account_id: !ref {model: account.account, search: "[('code','=','3200')]"}
+    account_id: !ref {model: account.account, search: "[('internal_type','=','receivable')]"}
     name: '[BASICCOMP] Basic Computer'
     price_unit: 600.0
     quantity: 10.0
@@ -249,7 +249,7 @@
   I add an invoice line to the invoice for XML-DD.
 -
   !record {model: account.invoice.line, id: dd_invoice_line_xml_dd, view: False}:
-    account_id: !ref {model: account.account, search: "[('code','=','3200')]"}
+    account_id: !ref {model: account.account, search: "[('internal_type','=','receivable')]"}
     name: '[BASICCOMP] Basic Computer'
     price_unit: 600.0
     quantity: 10.0

--- a/l10n_ch_lsv_dd/wizard/__init__.py
+++ b/l10n_ch_lsv_dd/wizard/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Swiss localization Direct Debit module for Odoo

--- a/l10n_ch_lsv_dd/wizard/dd_export_wizard.py
+++ b/l10n_ch_lsv_dd/wizard/dd_export_wizard.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Swiss localization Direct Debit module for OpenERP

--- a/l10n_ch_lsv_dd/wizard/export_utils.py
+++ b/l10n_ch_lsv_dd/wizard/export_utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Swiss localization Direct Debit module for OpenERP
@@ -86,7 +87,7 @@ def get_treatment_date(prefered_type, line_mat_date, order_sched_date, name,
     elif prefered_type == 'now':
         requested_date = today
     else:
-        raise exceptions.Warning('Preferred type not implemented')
+        raise exceptions.Warning(_('Preferred type not implemented'))
 
     # Accepted dates are in range -90 to +90 days. We could go up
     # to +1 year, but we should be sure that we have less than

--- a/l10n_ch_lsv_dd/wizard/invoice_free_wizard.py
+++ b/l10n_ch_lsv_dd/wizard/invoice_free_wizard.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    Swiss localization Direct Debit module for OpenERP

--- a/l10n_ch_pain_credit_transfer/tests/test_ch_sct.py
+++ b/l10n_ch_pain_credit_transfer/tests/test_ch_sct.py
@@ -2,11 +2,13 @@
 # © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp.addons.account.tests.account_test_classes\
-    import AccountingTestCase
-from openerp.tools import float_compare
-import time
 from lxml import etree
+import time
+
+from openerp.tools import float_compare
+
+from openerp.addons.account.tests.account_test_classes \
+    import AccountingTestCase
 
 ch_iban = 'CH15 3881 5158 3845 3843 7'
 
@@ -38,6 +40,14 @@ class TestSCT_CH(AccountingTestCase):
             'user_type_id',
             '=',
             self.env.ref('account.data_account_type_payable').id)], limit=1)
+        self.chf_currency = self.env.ref('base.CHF')
+        self.eur_currency = self.env.ref('base.EUR')
+        self.chf_currency.active = True
+        self.eur_currency.active = True
+        self.cr.execute('UPDATE res_company '
+                        'SET currency_id = %s '
+                        'WHERE id = %s',
+                        [self.chf_currency.id, self.main_company.id])
         # Create a swiss bank
         ch_bank1 = self.env['res.bank'].create({
             'name': 'Alternative Bank Schweiz AG',
@@ -70,9 +80,6 @@ class TestSCT_CH(AccountingTestCase):
             })
         self.payment_mode.payment_method_id.pain_version =\
             'pain.001.001.03.ch.02'
-        self.chf_currency = self.env.ref('base.CHF')
-        self.eur_currency = self.env.ref('base.EUR')
-        self.main_company.currency_id = self.chf_currency.id
         ch_bank2 = self.env['res.bank'].create({
             'name': 'Banque Cantonale Vaudoise',
             'bic': 'BCVLCH2LXXX',


### PR DESCRIPTION
The date from the PF statement is lost, as the file format diverges from the default one. This commit parses the correct date into account.bank.statement table.

I re-create this PR, as I needed quite a lot of rework to get travis green...
For a small change a lot of work :-)