### PR TITLE
[11.0] Enable SEPA payments when using Swiss pain.001 version

### DIFF
--- a/l10n_ch_pain_base/README.rst
+++ b/l10n_ch_pain_base/README.rst
@@ -36,6 +36,7 @@ Contributors
 * Alexis de Lattre <alexis.delattre@akretion.com>
 * Denis Leemann <denis.leemann@camptocamp.com>
 * Mykhailo Panarin <m.panarin@mobilunity.com>
+* Maxence Groine <mgroine@fiefmanage.ch>
 
 Maintainer
 ----------

--- a/l10n_ch_pain_base/__manifest__.py
+++ b/l10n_ch_pain_base/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Switzerland - ISO 20022",
     "summary": "ISO 20022 base module for Switzerland",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "category": "Finance",
     "author": "Akretion,Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/l10n_ch_pain_credit_transfer/README.rst
+++ b/l10n_ch_pain_credit_transfer/README.rst
@@ -47,6 +47,7 @@ Contributors
 * Alexis de Lattre <alexis.delattre@akretion.com>
 * Denis Leemann <denis.leemann@camptocamp.com>
 * Mykhailo Panarin <m.panarin@mobilunity.com>
+* Maxence Groine <mgroine@fiefmanage.ch>
 
 Maintainer
 ----------

--- a/l10n_ch_pain_credit_transfer/__manifest__.py
+++ b/l10n_ch_pain_credit_transfer/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Switzerland - PAIN Credit Transfer",
     "summary": "Generate ISO 20022 credit transfert (SEPA and not SEPA)",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "category": "Finance",
     "author": "Akretion,Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/l10n_ch_pain_credit_transfer/tests/test_ch_sct.py
+++ b/l10n_ch_pain_credit_transfer/tests/test_ch_sct.py
@@ -79,6 +79,10 @@ class TestSCT_CH(AccountingTestCase):
             'clearing': '767',
             'ccp': '01-1234-1',
         })
+        it_bank = self.env['res.bank'].create({
+            'name': 'Banca Popolare di Bergamo SpA',
+            'bic': 'BEPOIT21XXX',
+        })
         # Create a bank account with clearing 767
         self.agrolait_partner_bank = self.partner_bank_model.create({
             'acc_number': 'CH9100767000S00023455',
@@ -86,6 +90,11 @@ class TestSCT_CH(AccountingTestCase):
             'bank_id': ch_bank2.id,
             'ccp': '01-1234-1',
             })
+        self.agrolait_partner_bank_sepa = self.partner_bank_model.create({
+            'acc_number': 'IT60X0542811101000000123456',
+            'partner_id': self.partner_agrolait.id,
+            'bank_id': it_bank.id
+        })
 
     def test_sct_ch_payment_type1(self):
         invoice1 = self.create_invoice(
@@ -242,6 +251,48 @@ class TestSCT_CH(AccountingTestCase):
         sepa_xpath = xml_root.xpath(
             '//p:PmtInf/p:PmtTpInf/p:SvcLvl/p:Cd', namespaces=namespaces)
         self.assertEquals(len(sepa_xpath), 0)
+        local_instrument_xpath = xml_root.xpath(
+            '//p:PmtInf/p:PmtTpInf/p:LclInstrm/p:Prtry', namespaces=namespaces)
+        self.assertEquals(len(local_instrument_xpath), 0)
+
+        debtor_acc_xpath = xml_root.xpath(
+            '//p:PmtInf/p:DbtrAcct/p:Id/p:IBAN', namespaces=namespaces)
+        self.assertEquals(
+            debtor_acc_xpath[0].text,
+            self.payment_order.company_partner_bank_id.sanitized_acc_number)
+        self.payment_order.generated2uploaded()
+        self.assertEquals(self.payment_order.state, 'uploaded')
+        for inv in [invoice1, invoice2]:
+            self.assertEquals(inv.state, 'paid')
+        return
+
+    def test_sct_ch_payment_type5(self):
+        invoice1 = self.create_invoice(
+            self.partner_agrolait.id,
+            self.agrolait_partner_bank_sepa.id, self.eur_currency, 1234.56,
+            'none', 'Inv5555')
+        invoice2 = self.create_invoice(
+            self.partner_agrolait.id,
+            self.agrolait_partner_bank_sepa.id, self.eur_currency, 9012.52,
+            'none', 'Inv6666')
+        for inv in [invoice1, invoice2]:
+            action = inv.create_account_payment_line()
+
+        self.payment_order = self.payment_order_model.browse(action['res_id'])
+        self.payment_order.draft2open()
+        action = self.payment_order.open2generated()
+        self.assertEquals(self.payment_order.state, 'generated')
+        attachment = self.attachment_model.browse(action['res_id'])
+        xml_file = base64.b64decode(attachment.datas)
+        xml_root = etree.fromstring(xml_file)
+        namespaces = xml_root.nsmap
+        namespaces['p'] = xml_root.nsmap[None]
+        namespaces.pop(None)
+
+        sepa_xpath = xml_root.xpath(
+            '//p:PmtInf/p:PmtTpInf/p:SvcLvl/p:Cd', namespaces=namespaces)
+        self.assertEquals(len(sepa_xpath), 1)
+
         local_instrument_xpath = xml_root.xpath(
             '//p:PmtInf/p:PmtTpInf/p:LclInstrm/p:Prtry', namespaces=namespaces)
         self.assertEquals(len(local_instrument_xpath), 0)


### PR DESCRIPTION
Using the l10n_ch_pain_credit_transfer module, it is currently impossible to make SEPA orders using the Swiss pain version `pain.001.001.03.ch.02 (credit transfer in Switzerland)` while they are supported, according to the [SIX implementation guidelines](https://www.six-group.com/interbank-clearing/dam/downloads/en/standardization/iso/swiss-recommendations/implementation-guidelines-ct.pdf) (see p.18):

This PR aims at enabling SEPA ("Type 5") for payment orders that can support it, instead of "Type 6" payments, as would currently be generated.