### PR TITLE
Zürcher kantonalbank (ZKB) made recommended InstrID Mandatory...

### DIFF
--- a/l10n_ch_sepa/base_sepa/base_template/pain.001.001.03.xml.mako
+++ b/l10n_ch_sepa/base_sepa/base_template/pain.001.001.03.xml.mako
@@ -51,6 +51,7 @@
         </DbtrAgt>
         <CdtTrfTxInf>
           <PmtId>
+            <InstrId>${line.name}</InstrId>
             <EndToEndId>${line.name}</EndToEndId>
           </PmtId>
           <%block name="PmtTpInf"/>


### PR DESCRIPTION
The PAIN element InstrID is only "recommended" in the standard, therefore not created in the OCA code, but ZKB requires it...