### PR TITLE
[FIX] Remove wrong action that is present in other module

### DIFF
--- a/l10n_ch_lsv_dd/views/banking_export_ch_dd_view.xml
+++ b/l10n_ch_lsv_dd/views/banking_export_ch_dd_view.xml
@@ -68,10 +68,4 @@
       src_model="account.payment.order"
       view_type="form"
       view_mode="tree,form" />
-
-    <act_window id="action_account_invoice_free"
-      multi="True"
-      key2="client_action_multi" name="Free Invoices"
-      res_model="account.invoice.confirm" src_model="account.invoice"
-      view_mode="form" target="new" view_type="form" />
 </odoo>


### PR DESCRIPTION
This action is already defined [here](https://github.com/OCA/bank-payment/blob/10.0/account_payment_line_cancel/views/invoice_view.xml#L27), plus it's wrongly configurated in this module, calling `account.invoice.confirm` wizard instead of `account.invoice.free`