### PR TITLE
[10.0][FIX] Bypass unsupported address nodes in CH SEPA pain

### DIFF
--- a/l10n_ch_pain_credit_transfer/models/account_payment_order.py
+++ b/l10n_ch_pain_credit_transfer/models/account_payment_order.py
@@ -34,3 +34,12 @@ class AccountPaymentOrder(models.Model):
             parent_node, payment_info_ident,
             priority, local_instrument, category_purpose, sequence_type,
             requested_date, eval_ctx, gen_args)
+
+    @api.model
+    def _has_detailed_address(self, gen_args):
+        """
+        Swiss PAIN flavors don't support address details nodes
+        """
+        if 'ch' in gen_args.get('pain_flavor'):
+            return False
+        return super(AccountPaymentOrder, self)._has_detailed_address(gen_args)


### PR DESCRIPTION
This will fix CH Pain files validation. Depends on https://github.com/OCA/bank-payment/pull/569 refactor.