### PR TITLE
[10.0] l10n_ch_pain_base: Override address block for Swiss specs

### DIFF
--- a/l10n_ch_pain_base/__manifest__.py
+++ b/l10n_ch_pain_base/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Switzerland - ISO 20022",
     "summary": "ISO 20022 base module for Switzerland",
-    "version": "10.0.1.0.2",
+    "version": "10.0.1.0.3",
     "category": "Finance",
     "author": "Akretion,Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/l10n_ch_pain_base/models/account_payment_order.py
+++ b/l10n_ch_pain_base/models/account_payment_order.py
@@ -105,3 +105,25 @@ class AccountPaymentOrder(models.Model):
             return super(AccountPaymentOrder, self).generate_party_acc_number(
                 parent_node, party_type, order, partner_bank, gen_args,
                 bank_line=bank_line)
+
+    @api.model
+    def generate_address_block(
+            self, parent_node, partner, gen_args):
+        """Generate the piece of the XML corresponding to PstlAdr"""
+        if partner.country_id:
+            postal_address = etree.SubElement(parent_node, 'PstlAdr')
+
+            country = etree.SubElement(postal_address, 'Ctry')
+            country.text = self._prepare_field(
+                'Country', 'partner.country_id.code',
+                {'partner': partner}, 2, gen_args=gen_args)
+
+            adrline1 = etree.SubElement(postal_address, 'AdrLine')
+            adrline1.text = ', '.join(
+                filter(None, [partner.street, partner.street2])
+            )
+
+            adrline2 = etree.SubElement(postal_address, 'AdrLine')
+            adrline2.text = ' '.join([partner.zip, partner.city])
+
+        return True


### PR DESCRIPTION
Override address block generation to use only unstructured data as mixed content is not allowed
Need https://github.com/OCA/bank-payment/pull/570 to work
This fixes #461 