### PR TITLE
[10.0] l10n_ch_pain_base: Fix empty address block generation

### DIFF
--- a/l10n_ch_pain_base/__manifest__.py
+++ b/l10n_ch_pain_base/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Switzerland - ISO 20022",
     "summary": "ISO 20022 base module for Switzerland",
-    "version": "10.0.1.0.3",
+    "version": "10.0.1.0.4",
     "category": "Finance",
     "author": "Akretion,Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/l10n_ch_pain_base/models/account_payment_order.py
+++ b/l10n_ch_pain_base/models/account_payment_order.py
@@ -118,12 +118,14 @@ class AccountPaymentOrder(models.Model):
                 'Country', 'partner.country_id.code',
                 {'partner': partner}, 2, gen_args=gen_args)
 
-            adrline1 = etree.SubElement(postal_address, 'AdrLine')
-            adrline1.text = ', '.join(
-                filter(None, [partner.street, partner.street2])
-            )
+            if partner.street or partner.street2:
+                adrline1 = etree.SubElement(postal_address, 'AdrLine')
+                adrline1.text = ', '.join(
+                    filter(None, [partner.street, partner.street2])
+                )
 
-            adrline2 = etree.SubElement(postal_address, 'AdrLine')
-            adrline2.text = ' '.join([partner.zip, partner.city])
+                if partner.zip and partner.city:
+                    adrline2 = etree.SubElement(postal_address, 'AdrLine')
+                    adrline2.text = ' '.join([partner.zip, partner.city])
 
         return True


### PR DESCRIPTION
In the Swiss specifications, the block `AdrLine` must not be empty, so we do not include it if the partner does not have `street` and `street2` set.
Also, as per the specs, the first occurrence of this block has to be the address and the second occurrence the zip code + city. If the first is not included (no street and street2), the zip code and city must also not be included.