### PR TITLE
[11.0][FIX] l10n_ch_pain_base: incorrect compute_sepa_final_hook

### DIFF
--- a/l10n_ch_pain_base/models/account_payment_order.py
+++ b/l10n_ch_pain_base/models/account_payment_order.py
@@ -10,16 +10,6 @@ class AccountPaymentOrder(models.Model):
     _inherit = 'account.payment.order'
 
     @api.multi
-    def compute_sepa_final_hook(self, sepa):
-        self.ensure_one()
-        sepa = super().compute_sepa_final_hook(sepa)
-        pain_flavor = self.payment_mode_id.payment_method_id.pain_version
-        # ISR orders cannot be SEPA orders
-        if pain_flavor and '.ch.' in pain_flavor:
-            sepa = False
-        return sepa
-
-    @api.multi
     def generate_pain_nsmap(self):
         self.ensure_one()
         nsmap = super().generate_pain_nsmap()


### PR DESCRIPTION
Removed incorrect compute_sepa_final_hook from AccountPaymentOrder.
pain_flavor is the used xsd version for pain files, for example pain.001.001.03.ch.02.
If the "ch" is in pain_flavor, it doesn't mean that the used payment type is "ISR".

The pain.001.001.03.ch.02 definition covers all current possible payment types in Switzerland (national, cross-border, SEPA, etc.), see https://www.six-group.com/interbank-clearing/dam/downloads/en/standardization/iso/swiss-recommendations/implementation-guidelines-ct.pdf, sites 18 to 21.