### PR TITLE
[11.0][IMP] l10n_ch_account_tags Readme update

### DIFF
--- a/l10n_ch_account_tags/readme/USAGE.rst
+++ b/l10n_ch_account_tags/readme/USAGE.rst
@@ -3,7 +3,7 @@ To use this module, you need to:
   1. Install this module
 
 The tags will be created and the `account.account.template` will be updated. If
-you want to link automatically `account.acccount` to the tags, you need:
+you want to link automatically `account.acccount` to the tags, you need to:
 
   1. Install `account_chart_update` https://github.com/OCA/account-financial-tools/tree/11.0/account_chart_update
   2. Use it to `Update account`. https://github.com/OCA/account-financial-tools/tree/11.0/account_chart_update#usage

--- a/l10n_ch_account_tags/readme/USAGE.rst
+++ b/l10n_ch_account_tags/readme/USAGE.rst
@@ -1,3 +1,9 @@
 To use this module, you need to:
 
   1. Install this module
+
+The tags will be created and the `account.account.template` will be updated. If
+you want to link automatically `account.acccount` to the tags, you need:
+
+  1. Install `account_chart_update` https://github.com/OCA/account-financial-tools/tree/11.0/account_chart_update
+  2. Use it to `Update account`. https://github.com/OCA/account-financial-tools/tree/11.0/account_chart_update#usage


### PR DESCRIPTION
From scratch, the account.tags are created and linked to account.account.template.
But they are not linked to the already created .
The update of the README gives an easy hint for configuration. It hasn't been
added as a script, because of potential issues with multicompany.