### PR TITLE
Upgrade pyOpenSSL version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
   # to make pycrypto work in FDS module
   - pip install pip --upgrade
   - pip install pycrypto --upgrade
+  - pip install pyOpenSSL --upgrade
   - pip install unicodecsv xlrd pysftp wand
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}


### PR DESCRIPTION
In order to get rid of error

```
File "/home/travis/virtualenv/python2.7_with_system_site_packages/local/lib/python2.7/site-packages/pip/_vendor/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
  File "/usr/lib/python2.7/dist-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import rand, crypto, SSL
  File "/usr/lib/python2.7/dist-packages/OpenSSL/SSL.py", line 118, in <module>
    SSL_ST_INIT = _lib.SSL_ST_INIT
AttributeError: module object has no attribute 'SSL_ST_INIT'
```