### PR TITLE
[12.0] l10n_ch_payment_slip: Fix README error when generating missing terms …

### DIFF
--- a/l10n_ch_payment_slip/README.rst
+++ b/l10n_ch_payment_slip/README.rst
@@ -56,9 +56,7 @@ This is especialy useful when using pre-printed paper.
 Options also allow you to print the ISR in background when using
 white paper and printing customer address in the page header.
 
-By default address format on ISR is
-`%(street)s\n%(street2)s\n%(zip)s %(city)s`
-This can be change by setting System parameter
+Default address format on ISR can be change by setting System parameter:
 `isr.address.format`
 
 Usage

--- a/l10n_ch_payment_slip/readme/CONFIGURE.rst
+++ b/l10n_ch_payment_slip/readme/CONFIGURE.rst
@@ -6,7 +6,5 @@ This is especialy useful when using pre-printed paper.
 Options also allow you to print the ISR in background when using
 white paper and printing customer address in the page header.
 
-By default address format on ISR is
-`%(street)s\n%(street2)s\n%(zip)s %(city)s`
-This can be change by setting System parameter
+Default address format on ISR can be change by setting System parameter:
 `isr.address.format`


### PR DESCRIPTION
…(translations)

Without this Odoo raises following error:
File "/.repo_requirements/odoo/odoo/tools/translate.py", line 464, in quote
    assert r"\n" not in s, "Translation terms may not include escaped newlines ('\\n'), please use only literal newlines! (in '%s')" % s
AssertionError: Translation terms may not include escaped newlines ('\n'), please use only literal newlines! (in