### PR TITLE
[12.0] Update travis config to get rid of transifex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
+sudo: false
+cache: pip
 
 python:
   - "3.5"
-
-sudo: false
-cache: pip
 
 addons:
   postgresql: "9.6"
@@ -15,17 +14,12 @@ addons:
 
 env:
   global:
-  - VERSION="12.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
-  - TRANSIFEX_USER='transbot@odoo-community.org'
-  - secure: "AK5H2gTz//UqzpXRfXsFZOl7CYYGiHlP7nkQhUXCkdfjqVjK5FCtKZME9w3/C4qrx9nT7hwdfeKZ+slvUqvXbibJT0CCBHFUmcYsbAX3/o3j3sYccrsXWCUq17oPtmP2lMI4BC3eBgk1sfFQ+znfEF+DVyEoBuc0X2eg68U5/Ps="
+  - VERSION="12.0" TESTS="0" LINT_CHECK="0" MAKEPOT="0"
 
   matrix:
   - LINT_CHECK="1"
-  - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE=l10n_ch_dta
-#  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE=l10n_ch_dta
-  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE=l10n_ch_dta
-#  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE=l10n_ch_dta
+  - TESTS="1" ODOO_REPO="odoo/odoo" MAKEPOT="1"
+  - TESTS="1" ODOO_REPO="OCA/OCB"
 
 
 install:


### PR DESCRIPTION
We have some error with the job on transifex, which is now obsolete as we got the translation terms from weblate.

Updated from https://github.com/OCA/maintainer-quality-tools/blob/master/sample_files/.travis.yml