### PR TITLE
[12.0] l10n_ch_payment_slip: Fix ref assignation on move lines

### DIFF
--- a/l10n_ch_payment_slip/__manifest__.py
+++ b/l10n_ch_payment_slip/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {'name': 'Switzerland - ISR inpayment slip (PVR/BVR/ESR)',
  'summary': 'Print inpayment slip from your invoices',
- 'version': '12.0.2.1.0',
+ 'version': '12.0.3.1.0',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'category': 'Localization',
  'website': 'https://github.com/OCA/l10n-switzerland',
@@ -10,7 +10,6 @@
  'depends': [
      'account',
      'l10n_ch_base_bank',
-     'base_transaction_id',  # OCA/account-reconcile
      'web',
      'l10n_ch',
  ],

--- a/l10n_ch_payment_slip/tests/test_payment_slip.py
+++ b/l10n_ch_payment_slip/tests/test_payment_slip.py
@@ -101,11 +101,10 @@ class TestPaymentSlip(common.SavepointCase):
         """Test that confirming an invoice generate slips correctly"""
         invoice = self.make_invoice()
         self.assertTrue(invoice.move_id)
-        for line in invoice.move_id.line_ids:
-            if line.account_id.user_type_id.type in ('payable', 'receivable'):
-                self.assertTrue(line.transaction_ref)
-            else:
-                self.assertFalse(line.transaction_ref)
+        self.assertTrue(invoice.move_id.ref)
+        self.assertEqual(
+            invoice.isr_reference.replace(' ', ''), invoice.move_id.ref
+        )
         for line in invoice.move_id.line_ids:
             slip = self.env['l10n_ch.payment_slip'].search(
                 [('move_line_id', '=', line.id)]


### PR DESCRIPTION
Payment slip ref on invoice move was overwritten by the
super call to invoice_validate that was done after the
setting of payment slip ref on the move.

Moreover, the dependency to base_transaction_id is dropped
as the reference is now written on account.move.ref field.

Linked to https://github.com/OCA/account-reconcile/pull/292