### PR TITLE
[FIX] Use residual instead of debit, useful for partial payment

### DIFF
--- a/l10n_ch_payment_slip/models/payment_slip.py
+++ b/l10n_ch_payment_slip/models/payment_slip.py
@@ -129,7 +129,7 @@ class PaymentSlip(models.Model):
         :return: total amount of payment slip
         :rtype: float
         """
-        return self.move_line_id.debit
+        return self.move_line_id.amount_residual
 
     @api.depends('move_line_id',
                  'move_line_id.debit',


### PR DESCRIPTION
* Purpose
Actually we use debit, but in case of a partial paiement, we want to be able to resend the invoice, so we use amount_residual