### PR TITLE
[12.0] payment_slip: Fix variable referenced before assignment

### DIFF
--- a/l10n_ch_payment_slip/models/invoice.py
+++ b/l10n_ch_payment_slip/models/invoice.py
@@ -64,7 +64,10 @@ class FutureAccountInvoice(models.Model):
         for record in self:
             isr_subs = False
             isr_subs_formatted = False
-            if record.partner_bank_id:
+            if (
+                record.partner_bank_id and
+                record.currency_id.name in ['EUR', 'CHF']
+            ):
                 bank_acc = record.partner_bank_id
                 if record.currency_id.name == 'EUR':
                     isr_subscription = bank_acc.l10n_ch_isr_subscription_eur


### PR DESCRIPTION
Fix variable referenced before assignment when currency is not in (EUR, CHF)