### PR TITLE
[12.0] [FIX] l10n_ch_payment_slip correct view dependency

### DIFF
--- a/l10n_ch_payment_slip/views/account_invoice.xml
+++ b/l10n_ch_payment_slip/views/account_invoice.xml
@@ -12,7 +12,7 @@
       <field name="name">account.invoice.form.isr.ref</field>
       <field name="model">account.invoice</field>
       <field name="type">form</field>
-      <field name="inherit_id" ref="account.invoice_form"/>
+      <field name="inherit_id" ref="l10n_ch.isr_invoice_form"/>
       <field name="arch" type="xml">
         <xpath expr="//button[@name='isr_print']" position="attributes">
           <attribute name="invisible">1</attribute>


### PR DESCRIPTION
The view hides then button "isr_print" and then should inherit on the view that puts that button, which is l10n_ch.isr_invoice_form
That's fine as long as the module l10n_ch_payment_slip depends on l10n_ch