### PR TITLE
[12.0] [FIX] l10n_ch_payment_slip : Fix javascript

### DIFF
--- a/l10n_ch_payment_slip/static/src/js/qwebactionmanager.js
+++ b/l10n_ch_payment_slip/static/src/js/qwebactionmanager.js
@@ -4,34 +4,38 @@ odoo.define('l10n_ch_payment_slip.report', function (require) {
     var ActionManager= require('web.ActionManager');
     var crash_manager = require('web.crash_manager');
     var framework = require('web.framework');
-
+    var session = require('web.session');
 
     ActionManager.include({
-        ir_actions_report: function (action, options) {
-            var report_url = '';
-
+        _executeReportAction: function (action, options) {
             if (action.report_type !== 'reportlab-pdf') {
                 return this._super(action, options);
             }
             framework.blockUI();
-            report_url = '/report/reportlab-pdf/'.concat(
+            var def = $.Deferred();
+            var report_url  = '/report/reportlab-pdf/'.concat(
                 action.report_name, '/',
                 action.context.active_ids.join(',')
             );
-            this.getSession().get_file({
+            var blocked = !session.get_file({
                 url: report_url,
                 data:{
                     data: JSON.stringify([report_url, action.report_type]),
                 },
                 error: crash_manager.rpc_error.bind(crash_manager),
-                success: function () {
-                    if (action && options && !action.dialog) {
-                        options.on_close();
-                    }
-                },
+                success: def.resolve.bind(def),
+                complete: framework.unblockUI,
             });
-            framework.unblockUI();
-            return;
+            if (blocked) {
+                // AAB: this check should be done in get_file service directly,
+                // should not be the concern of the caller (and that way, get_file
+                // could return a deferred)
+                var message = _t('A popup window with your report was blocked. You ' +
+                                 'may need to change your browser settings to allow ' +
+                                 'popup windows for this page.');
+                this.do_warn(_t('Warning'), message, true);
+            }
+            return def;
         },
     });
 });


### PR DESCRIPTION
Clicking on "Print ISR" from an invoice will throw the following error (visible in the developer console): "The ActionManager can't handle reports of type reportlab-pdf"
It seems that the javascrpt had not been tested and not ported to v12.0 framework.
Here is the PR for v12.0