### PR TITLE
[12.0] account_invoice_with_payment - Do not forward default_type context key to the report

### DIFF
--- a/l10n_ch_invoice_with_payment/models/report.py
+++ b/l10n_ch_invoice_with_payment/models/report.py
@@ -9,12 +9,17 @@ class IrActionsReport(models.Model):
 
     @api.multi
     def render_qweb_pdf(self, res_ids=None, data=None):
+        ctx = self.env.context
+        # Remove context key that comes from invoice action
+        if ctx.get('default_type'):
+            ctx = ctx.copy()
+            ctx.pop('default_type')
         if (self.report_name != 'l10n_ch_invoice_with_payment.'
                 'report_invoice_with_paymentslip' or not res_ids):
             return super().render_qweb_pdf(res_ids, data)
         inv_report = self._get_report_from_name('account.report_invoice')
         invoice_pdf, _ = inv_report.with_context(
-            self.env.context).render_qweb_pdf(res_ids, data)
+            ctx).render_qweb_pdf(res_ids, data)
         invoice_pdf_io = io.BytesIO(invoice_pdf)
 
         slip_report = self._get_report_from_name(


### PR DESCRIPTION
The context key 'default_type' can be added by an action.
It is the case if you create an invoice after having navigated
through the "Invoiced" smart button on partner form.
This context key is only intended for the invoice and shall not be
passed to the report.