### PR TITLE
[IMP] add possibility to send file without BIC set

### DIFF
--- a/l10n_ch_pain_base/__openerp__.py
+++ b/l10n_ch_pain_base/__openerp__.py
@@ -17,6 +17,7 @@
     "data": [
         'views/account_payment_line.xml',
         'views/bank_payment_line.xml',
+        'views/account_payment_method_view.xml'
         ],
     'installable': True,
 }

--- a/l10n_ch_pain_base/models/__init__.py
+++ b/l10n_ch_pain_base/models/__init__.py
@@ -3,3 +3,4 @@
 from . import account_payment_order
 from . import account_payment_line
 from . import account_move_line
+from . import account_payment_method

--- a/l10n_ch_pain_base/models/account_payment_method.py
+++ b/l10n_ch_pain_base/models/account_payment_method.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# © 2013-2016 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import fields, models
+
+
+class AccountPaymentMethod(models.Model):
+    _inherit = 'account.payment.method'
+
+    bic_required = fields.Boolean(
+        string='BIC Required', default=True,
+        help="If active, Odoo will ask for a BIC when generating the file")

--- a/l10n_ch_pain_base/models/account_payment_order.py
+++ b/l10n_ch_pain_base/models/account_payment_order.py
@@ -68,7 +68,8 @@ class AccountPaymentOrder(models.Model):
             if bank_line.local_instrument == 'CH01':
                 # Don't set the creditor agent on BVR/CH01 payments
                 return True
-            elif not partner_bank.bank_bic:
+            elif not partner_bank.bank_bic and \
+                    self.payment_method_id.bic_required:
                 raise UserError(_(
                     "For pain.001.001.03.ch.02, for non-BVR payments, "
                     "the BIC is required on the bank '%s' related to the "

--- a/l10n_ch_pain_base/views/account_payment_method_view.xml
+++ b/l10n_ch_pain_base/views/account_payment_method_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+
+
+<record id="account_payment_method_bic_form" model="ir.ui.view">
+    <field name="name">pain_base.account_payment_bic_method.form</field>
+    <field name="model">account.payment.method</field>
+    <field name="inherit_id" ref="account_payment_mode.account_payment_method_form"/>
+    <field name="arch" type="xml">
+        <field name="payment_type" position="after">
+            <field name="bic_required" attrs="{'invisible': [('pain_version', '=', False)]}"/>
+        </field>
+    </field>
+</record>
+
+</data>
+</openerp>


### PR DESCRIPTION
* Purpose
WE need to be able to send SEPA file without BIC, it's not necessary to make a payment.
I have add it as an option, by default is checked (to keep the same process), but can be deactivated

