### PR TITLE
[13.0][MIG] l10n_ch_isr_payment_grouping

### DIFF
--- a/l10n_ch_isr_payment_grouping/__init__.py
+++ b/l10n_ch_isr_payment_grouping/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ch_isr_payment_grouping/__manifest__.py
+++ b/l10n_ch_isr_payment_grouping/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2012-2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Switzerland - ISR payment grouping",
+    "summary": "Extend account to ungroup ISR",
+    "version": "12.0.1.0.0",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "category": "Localization",
+    "website": "https://github.com/OCA/l10n-switzerland",
+    "license": "AGPL-3",
+    "depends": ["account", "l10n_ch"],
+    "data": [],
+    "auto_install": False,
+    "installable": True,
+}

--- a/l10n_ch_isr_payment_grouping/__manifest__.py
+++ b/l10n_ch_isr_payment_grouping/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Switzerland - ISR payment grouping",
     "summary": "Extend account to ungroup ISR",
-    "version": "12.0.1.0.0",
+    "version": "13.0.1.0.0",
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "category": "Localization",
     "website": "https://github.com/OCA/l10n-switzerland",

--- a/l10n_ch_isr_payment_grouping/models/__init__.py
+++ b/l10n_ch_isr_payment_grouping/models/__init__.py
@@ -1,0 +1,3 @@
+from . import account_invoice
+from . import account_payment
+from . import res_bank

--- a/l10n_ch_isr_payment_grouping/models/__init__.py
+++ b/l10n_ch_isr_payment_grouping/models/__init__.py
@@ -1,3 +1,3 @@
-from . import account_invoice
+from . import account_move
 from . import account_payment
 from . import res_bank

--- a/l10n_ch_isr_payment_grouping/models/account_invoice.py
+++ b/l10n_ch_isr_payment_grouping/models/account_invoice.py
@@ -1,0 +1,39 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import re
+
+from odoo import models
+from odoo.tools.misc import mod10r
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    def _get_invoice_reference_ch_invoice(self):
+        """ This sets ISR reference number which is generated based on customer's `Bank Account` and set it as
+        `Payment Reference` of the invoice when invoice's journal is using Switzerland's communication standard
+        """
+        self.ensure_one()
+        return self.l10n_ch_isr_number
+
+    def _get_invoice_reference_ch_partner(self):
+        """ This sets ISR reference number which is generated based on customer's `Bank Account` and set it as
+        `Payment Reference` of the invoice when invoice's journal is using Switzerland's communication standard
+        """
+        self.ensure_one()
+        return self.l10n_ch_isr_number
+
+    def _is_isr_supplier_invoice(self):
+        """Check for payments that a supplier invoice has a bank account
+        that can issue ISR and that the reference is an ISR reference number"""
+        # We consider a structured ref can only be in `reference` whereas in v13
+        # it can be in 2 different fields
+        ref = self.reference
+        if (
+            ref
+            and self.partner_bank_id.is_isr_issuer()
+            and re.match(r"^(\d{2,27}|\d{2}( \d{5}){5})$", ref)
+        ):
+            ref = ref.replace(" ", "")
+            return ref == mod10r(ref[:-1])
+        return False

--- a/l10n_ch_isr_payment_grouping/models/account_move.py
+++ b/l10n_ch_isr_payment_grouping/models/account_move.py
@@ -6,19 +6,23 @@ from odoo import models
 from odoo.tools.misc import mod10r
 
 
-class AccountInvoice(models.Model):
-    _inherit = "account.invoice"
+class AccountMove(models.Model):
+    _inherit = "account.move"
 
     def _get_invoice_reference_ch_invoice(self):
-        """ This sets ISR reference number which is generated based on customer's `Bank Account` and set it as
-        `Payment Reference` of the invoice when invoice's journal is using Switzerland's communication standard
+        """ This sets ISR reference number which is generated based on
+        customer's `Bank Account` and set it as `Payment Reference` of
+        the invoice when invoice's journal is using Switzerland's
+        communication standard
         """
         self.ensure_one()
         return self.l10n_ch_isr_number
 
     def _get_invoice_reference_ch_partner(self):
-        """ This sets ISR reference number which is generated based on customer's `Bank Account` and set it as
-        `Payment Reference` of the invoice when invoice's journal is using Switzerland's communication standard
+        """ This sets ISR reference number which is generated based on
+        customer's `Bank Account` and set it as `Payment Reference` of the
+        invoice when invoice's journal is using Switzerland's communication
+        standard
         """
         self.ensure_one()
         return self.l10n_ch_isr_number
@@ -28,10 +32,10 @@ class AccountInvoice(models.Model):
         that can issue ISR and that the reference is an ISR reference number"""
         # We consider a structured ref can only be in `reference` whereas in v13
         # it can be in 2 different fields
-        ref = self.reference
+        ref = self.invoice_payment_ref or self.ref
         if (
             ref
-            and self.partner_bank_id.is_isr_issuer()
+            and self.invoice_partner_bank_id.is_isr_issuer()
             and re.match(r"^(\d{2,27}|\d{2}( \d{5}){5})$", ref)
         ):
             ref = ref.replace(" ", "")

--- a/l10n_ch_isr_payment_grouping/models/account_payment.py
+++ b/l10n_ch_isr_payment_grouping/models/account_payment.py
@@ -1,0 +1,63 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, models
+
+from odoo.addons.account.models.account_payment import MAP_INVOICE_TYPE_PARTNER_TYPE
+
+class AbstractPayment(models.AbstractModel):
+    _inherit = "account.abstract.payment"
+
+    @api.model
+    def is_multi(self, invoices):
+        """Override computation of `multi` when multiple ISR are present"""
+        multi = super().is_multi(invoices)
+        # Look if we are mixin ISR ref invoices with vendor bills
+        if multi:
+            return multi
+        isr_invoices = invoices.filtered(lambda rec:
+                rec._is_isr_supplier_invoice())
+        multi_isr = any(inv.reference != isr_invoices[0] for inv in isr_invoices)
+        return multi_isr
+
+
+class PaymentRegister(models.TransientModel):
+    """Backport from v13 of extend of account.payment.register"""
+
+    _inherit = "account.register.payments"
+
+    def _prepare_communication(self, invoices):
+        """Return a single ISR reference
+
+        to avoid duplicate of the same number when multiple payments are done
+        on the same reference. As those payments are grouped by reference,
+        we want a unique reference in communication.
+
+        """
+        # Only the first invoice needs to be tested as the grouping ensure
+        # invoice with same ISR are in the same group.
+        if invoices[0]._is_isr_supplier_invoice():
+            return invoices[0].reference
+        else:
+            return super()._prepare_communication(invoices)
+
+    def _get_payment_group_key(self, inv):
+        """Define group key to group invoices in payments.
+        In case of ISR reference number on the supplier invoice
+        the group rule must separate the invoices by payment refs.
+
+        As such reference is structured. This is required to export payments
+        to bank in batch.
+        """
+        if inv._is_isr_supplier_invoice():
+
+            ref = inv.reference
+            if inv.partner_id.type == 'invoice':
+                partner_id = inv.partner_id.id
+            else:
+                partner_id = inv.commercial_partner_id.id
+            account_id = inv.account_id.id
+            invoice_type = MAP_INVOICE_TYPE_PARTNER_TYPE[inv.type]
+            recipient_account = inv.partner_bank_id
+            return (partner_id, account_id, invoice_type, recipient_account, ref)
+        else:
+            return super()._get_payment_group_key(inv)

--- a/l10n_ch_isr_payment_grouping/models/account_payment.py
+++ b/l10n_ch_isr_payment_grouping/models/account_payment.py
@@ -1,29 +1,12 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import api, models
-
-from odoo.addons.account.models.account_payment import MAP_INVOICE_TYPE_PARTNER_TYPE
-
-class AbstractPayment(models.AbstractModel):
-    _inherit = "account.abstract.payment"
-
-    @api.model
-    def is_multi(self, invoices):
-        """Override computation of `multi` when multiple ISR are present"""
-        multi = super().is_multi(invoices)
-        # Look if we are mixin ISR ref invoices with vendor bills
-        if multi:
-            return multi
-        isr_invoices = invoices.filtered(lambda rec:
-                rec._is_isr_supplier_invoice())
-        multi_isr = any(inv.reference != isr_invoices[0] for inv in isr_invoices)
-        return multi_isr
+from odoo import models
 
 
 class PaymentRegister(models.TransientModel):
     """Backport from v13 of extend of account.payment.register"""
 
-    _inherit = "account.register.payments"
+    _inherit = "account.payment.register"
 
     def _prepare_communication(self, invoices):
         """Return a single ISR reference
@@ -36,7 +19,7 @@ class PaymentRegister(models.TransientModel):
         # Only the first invoice needs to be tested as the grouping ensure
         # invoice with same ISR are in the same group.
         if invoices[0]._is_isr_supplier_invoice():
-            return invoices[0].reference
+            return invoices[0].invoice_payment_ref or invoices[0].ref
         else:
             return super()._prepare_communication(invoices)
 
@@ -50,14 +33,12 @@ class PaymentRegister(models.TransientModel):
         """
         if inv._is_isr_supplier_invoice():
 
-            ref = inv.reference
-            if inv.partner_id.type == 'invoice':
-                partner_id = inv.partner_id.id
-            else:
-                partner_id = inv.commercial_partner_id.id
-            account_id = inv.account_id.id
-            invoice_type = MAP_INVOICE_TYPE_PARTNER_TYPE[inv.type]
-            recipient_account = inv.partner_bank_id
-            return (partner_id, account_id, invoice_type, recipient_account, ref)
+            ref = inv.invoice_payment_ref or inv.ref
+            return (
+                inv.commercial_partner_id,
+                inv.currency_id,
+                inv.invoice_partner_bank_id,
+                ref,
+            )
         else:
             return super()._get_payment_group_key(inv)

--- a/l10n_ch_isr_payment_grouping/models/res_bank.py
+++ b/l10n_ch_isr_payment_grouping/models/res_bank.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import re
+
+from odoo import api, fields, models, _
+from odoo.tools.misc import mod10r
+
+import werkzeug.urls
+
+
+def _is_l10n_ch_qr_iban(account_ref):
+    """Returns if the account_ref is a QR IBAN
+
+    A QR IBAN contains an IID QR.
+    An IID QR is between 30000 and 31999
+    It starts at the 5th character
+    eg: CH21 3080 8001 2345 6782 7
+    where 30808 is the IID QR
+    """
+    account_ref = account_ref.replace(" ", "")
+    return (
+        account_ref.startswith("CH")
+        and account_ref[4:9] >= "30000"
+        and account_ref[4:9] <= "31999"
+    )
+
+
+class ResPartnerBank(models.Model):
+    _inherit = "res.partner.bank"
+
+    def is_isr_issuer(self):
+        """Supplier will provide ISR reference numbers in two cases:
+
+        - postal account number starting by 01 or 03
+        - QR-IBAN
+        """
+        # acc_type can be bank for isrb
+        if self.acc_type in ["bank", "postal"] and self.l10n_ch_postal:
+            return self.l10n_ch_postal[:2] in ["01", "03"]
+        return self.acc_type == "iban" and _is_l10n_ch_qr_iban(self.acc_number)

--- a/l10n_ch_isr_payment_grouping/models/res_bank.py
+++ b/l10n_ch_isr_payment_grouping/models/res_bank.py
@@ -1,11 +1,6 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-import re
-
-from odoo import api, fields, models, _
-from odoo.tools.misc import mod10r
-
-import werkzeug.urls
+from odoo import models
 
 
 def _is_l10n_ch_qr_iban(account_ref):

--- a/l10n_ch_isr_payment_grouping/readme/CONTRIBUTORS.rst
+++ b/l10n_ch_isr_payment_grouping/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Yannick Vaucher <yannick.vaucher@camptocamp.com>

--- a/l10n_ch_isr_payment_grouping/readme/DESCRIPTION.rst
+++ b/l10n_ch_isr_payment_grouping/readme/DESCRIPTION.rst
@@ -1,0 +1,18 @@
+Definintion of a specific grouping rule for ISR payments
+
+This module is recommended if you use SEPA pain files.
+
+Usually to reduce payment fees, you want to group
+Vendor Bills by supplier in your payments.
+In case of Swiss SEPA with ISR we want to keep a single transaction per ISR
+and the additionnal fees per payment doesn't apply.
+
+Moreover grouping payments usually concatenate the Vendor references
+and make it more difficult for your suppliers to reconciliate
+your payments as multiple ISR references concatenated are not supported
+in SEPA file format.
+
+This module checks if a payment is an ISR payment:
+
+ISR: never group payments
+other: standard grouping

--- a/l10n_ch_isr_payment_grouping/readme/INSTALL.rst
+++ b/l10n_ch_isr_payment_grouping/readme/INSTALL.rst
@@ -1,0 +1,3 @@
+This requires the following patch on odoo:
+
+https://github.com/odoo/odoo/pull/48441

--- a/l10n_ch_isr_payment_grouping/readme/USAGE.rst
+++ b/l10n_ch_isr_payment_grouping/readme/USAGE.rst
@@ -1,0 +1,12 @@
+Once installed this module will automatically ungroup the ISR payments.
+
+Wether you check or not the `Group Invoices` checkbox ISR payments are split
+by ISR reference.
+
+The ISR reference is read from the `Vendor Reference` field on Vendor Bill.
+
+To consider Vendor Bill as using ISR, it must have:
+
+- an ISR reference
+- a bank account with a valid ISR issuer
+  postal account starting with 01 or 03

--- a/l10n_ch_isr_payment_grouping/tests/__init__.py
+++ b/l10n_ch_isr_payment_grouping/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_l10n_ch_payment_isr

--- a/l10n_ch_isr_payment_grouping/tests/test_l10n_ch_payment_isr.py
+++ b/l10n_ch_isr_payment_grouping/tests/test_l10n_ch_payment_isr.py
@@ -1,0 +1,365 @@
+from odoo import tools
+from odoo.modules.module import get_resource_path
+from odoo.exceptions import ValidationError
+from odoo.tests import common, tagged
+
+import time
+
+ISR1 = "703192500010549027000209403"
+ISR2 = "120000000000234478943216899"
+
+
+@tagged("post_install", "-at_install")
+class PaymentISR(common.TransactionCase):
+    """Test grouping of payment by ISR reference"""
+
+    def _load(self, module, *args):
+        tools.convert_file(
+            self.cr,
+            "l10n_ch",
+            get_resource_path(module, *args),
+            {},
+            "init",
+            False,
+            "test",
+            self.registry._assertion_report,
+        )
+
+    def create_supplier_invoice(
+        self, supplier, ref, currency_to_use="base.CHF", inv_date=None
+    ):
+        """ Generates a test invoice """
+        product = self.env.ref("product.product_product_4")
+        invoice = (
+            self.env["account.invoice"]
+            .with_context(default_type="out_invoice")
+            .create(
+                {
+                    "type": "in_invoice",
+                    "reference": ref,
+                    "partner_id": supplier.id,
+                    "currency_id": self.env.ref(currency_to_use).id,
+                    "date_invoice": inv_date or time.strftime("%Y") + "-12-22",
+                    "invoice_line_ids": [
+                        (
+                            0,
+                            0,
+                            {
+                                "name": product.name,
+                                "product_id": product.id,
+                                "account_id": self.env["account.account"]
+                                .search(
+                                    [
+                                        (
+                                            "user_type_id",
+                                            "=",
+                                            self.env.ref(
+                                                "account.data_account_type_revenue"
+                                            ).id,
+                                        )
+                                    ],
+                                    limit=1,
+                                )
+                                .id,
+                                "quantity": 1,
+                                "price_unit": 42,
+                            },
+                        )
+                    ],
+                }
+            )
+        )
+        invoice.action_invoice_open()
+
+        return invoice
+
+    def create_bank_account(self, number, partner, bank=None):
+        """ Generates a test res.partner.bank. """
+        return self.env["res.partner.bank"].create(
+            {"acc_number": number, "bank_id": bank.id, "partner_id": partner.id}
+        )
+
+    def create_isrb_account(self, number, partner):
+        """ Generates a test res.partner.bank. """
+        return self.env["res.partner.bank"].create(
+            {
+                "acc_number": partner.name + number,
+                "l10n_ch_postal": number,
+                "partner_id": partner.id,
+            }
+        )
+
+    def setUp(self):
+        super().setUp()
+        self._load("account", "test", "account_minimal_test.xml")
+        self.payment_method_manual_in = self.env.ref(
+            "account.account_payment_method_manual_in"
+        )
+        abs_bank = self.env["res.bank"].create(
+            {"name": "Alternative Bank Schweiz", "bic": "ABSOCH22XXX"}
+        )
+
+        self.bank_journal_chf = self.env["account.journal"].create(
+            {"name": "Bank", "type": "bank", "code": "BNK41"}
+        )
+        self.supplier_isrb1 = self.env["res.partner"].create({"name": "Supplier ISR 1"})
+        self.create_isrb_account("01-162-8", self.supplier_isrb1)
+        self.supplier_isrb2 = self.env["res.partner"].create({"name": "Supplier ISR 2"})
+        self.create_isrb_account("01-162-8", self.supplier_isrb2)
+        self.supplier_iban = self.env["res.partner"].create({"name": "Supplier IBAN"})
+        self.create_bank_account(
+            "CH61 0839 0107 6280 0100 0", self.supplier_iban, abs_bank
+        )
+
+    def test_payment_isr_grouping(self):
+        """Create multiple invoices to test grouping by partner and ISR
+
+        """
+        invoices = (
+            self.create_supplier_invoice(self.supplier_isrb1, ISR1)
+            | self.create_supplier_invoice(self.supplier_isrb1, ISR2)
+            # using same vendor reference is not supporter in v12
+            # | self.create_supplier_invoice(self.supplier_isrb1, ISR2, inv_date=time.strftime('%Y') + '-12-23')
+            | self.create_supplier_invoice(self.supplier_isrb2, ISR2)
+            | self.create_supplier_invoice(self.supplier_iban, "1234")
+            | self.create_supplier_invoice(self.supplier_iban, "5678")
+        )
+        # create an invoice where ref is set instead of invoice_payment_ref
+        # only valable for v13
+        # inv_ref = self.create_supplier_invoice(self.supplier_isrb1, False)
+        # inv_ref.reference = ISR2
+        # invoices |= inv_ref
+        inv_no_ref = self.create_supplier_invoice(self.supplier_iban, False)
+        invoices |= inv_no_ref
+        # create an invoice where ref is set instead of invoice_payment_ref
+        PaymentRegister = self.env["account.register.payments"]
+        ctx = {"active_model": "account.invoice", "active_ids": invoices.ids}
+        register = PaymentRegister.with_context(ctx).create(
+            {
+                "payment_date": time.strftime("%Y") + "-12-28",
+                "journal_id": self.bank_journal_chf.id,
+                "payment_method_id": self.payment_method_manual_in.id,
+                "group_invoices": True,
+            }
+        )
+
+        vals = register.get_payments_vals()
+        self.assertEqual(len(vals), 4)
+        expected_vals = [
+            # ref, partner, invoice count, amount
+            # 3 invoices #2, #3 and inv_ref grouped in one payment with a single ref
+            # due to unsuported duplicate ref results differs from v13
+            # (ISR2, self.supplier_isrb1.id, 3, 126.0),
+            (ISR2, self.supplier_isrb1.id, 1, 42.0),
+            # different partner, different payment
+            (ISR2, self.supplier_isrb2.id, 1, 42.0),
+            # different ISR reference, different payment
+            (ISR1, self.supplier_isrb1.id, 1, 42.0),
+            # not ISR, standard grouping
+            (
+                "{} 5678 1234".format(inv_no_ref.move_name),
+                self.supplier_iban.id,
+                3,
+                126.0,
+            ),
+        ]
+        self.assertEqual(
+            [
+                (
+                    v["communication"],
+                    v["partner_id"],
+                    len(v["invoice_ids"][0][2]),
+                    v["amount"],
+                )
+                for v in sorted(
+                    vals, key=lambda i: (i["communication"], i["partner_id"])
+                )
+            ],
+            expected_vals,
+        )
+
+    def test_payment_isr_grouping_single_supplier(self):
+        """Test grouping of ISR on a single supplier
+
+        No grouping on ISR should apply
+
+        """
+        invoices = (
+            self.create_supplier_invoice(self.supplier_isrb1, ISR1)
+            | self.create_supplier_invoice(self.supplier_isrb1, ISR2)
+            # using same vendor reference is not supporter in v12
+            # | self.create_supplier_invoice(self.supplier_isrb1, ISR2, inv_date=time.strftime('%Y') + '-12-23')
+        )
+        # create an invoice where ref is set instead of invoice_payment_ref
+        PaymentRegister = self.env["account.register.payments"]
+        ctx = {"active_model": "account.invoice", "active_ids": invoices.ids}
+        register = PaymentRegister.with_context(ctx).create(
+            {
+                "payment_date": time.strftime("%Y") + "-12-28",
+                "journal_id": self.bank_journal_chf.id,
+                "payment_method_id": self.payment_method_manual_in.id,
+                "group_invoices": True,
+            }
+        )
+
+        vals = register.get_payments_vals()
+        self.assertEqual(len(vals), 2)
+        expected_vals = [
+            # ref, partner, invoice count, amount
+            # 3 invoices #2, #3 and inv_ref grouped in one payment with a single ref
+            # due to unsuported duplicate ref results differs from v13
+            # (ISR2, self.supplier_isrb1.id, 3, 126.0),
+            (ISR2, self.supplier_isrb1.id, 1, 42.0),
+            # different ISR reference, different payment
+            (ISR1, self.supplier_isrb1.id, 1, 42.0),
+        ]
+        self.assertEqual(
+            [
+                (
+                    v["communication"],
+                    v["partner_id"],
+                    len(v["invoice_ids"][0][2]),
+                    v["amount"],
+                )
+                for v in sorted(
+                    vals, key=lambda i: (i["communication"], i["partner_id"])
+                )
+            ],
+            expected_vals,
+        )
+
+    def test_payment_isr_single_supplier(self):
+        """Test grouping of ISR on a single supplier
+
+        No grouping on ISR should apply
+
+        """
+        invoices = (
+            self.create_supplier_invoice(self.supplier_isrb1, ISR1)
+            | self.create_supplier_invoice(self.supplier_isrb1, ISR2)
+            # using same vendor reference is not supporter in v12
+            # | self.create_supplier_invoice(self.supplier_isrb1, ISR2, inv_date=time.strftime('%Y') + '-12-23')
+        )
+        # create an invoice where ref is set instead of invoice_payment_ref
+        PaymentRegister = self.env["account.register.payments"]
+        ctx = {"active_model": "account.invoice", "active_ids": invoices.ids}
+        register = PaymentRegister.with_context(ctx).create(
+            {
+                "payment_date": time.strftime("%Y") + "-12-28",
+                "journal_id": self.bank_journal_chf.id,
+                "payment_method_id": self.payment_method_manual_in.id,
+                "group_invoices": True,
+            }
+        )
+
+        vals = register.get_payments_vals()
+        self.assertEqual(len(vals), 2)
+        expected_vals = [
+            # ref, partner, invoice count, amount
+            # 3 invoices #2, #3 and inv_ref grouped in one payment with a single ref
+            # due to unsuported duplicate ref results differs from v13
+            # (ISR2, self.supplier_isrb1.id, 3, 126.0),
+            (ISR2, self.supplier_isrb1.id, 1, 42.0),
+            # different ISR reference, different payment
+            (ISR1, self.supplier_isrb1.id, 1, 42.0),
+        ]
+        self.assertEqual(
+            [
+                (
+                    v["communication"],
+                    v["partner_id"],
+                    len(v["invoice_ids"][0][2]),
+                    v["amount"],
+                )
+                for v in sorted(
+                    vals, key=lambda i: (i["communication"], i["partner_id"])
+                )
+            ],
+            expected_vals,
+        )
+
+    def test_payment_non_isr_grouping_single_supplier(self):
+        """Test grouping of non ISR on a single partner
+
+        Grouping on free ref should apply
+
+        """
+        invoices = self.create_supplier_invoice(
+            self.supplier_iban, "INV1"
+        ) | self.create_supplier_invoice(self.supplier_iban, "INV2")
+        # create an invoice where ref is set instead of invoice_payment_ref
+        PaymentRegister = self.env["account.register.payments"]
+        ctx = {"active_model": "account.invoice", "active_ids": invoices.ids}
+        register = PaymentRegister.with_context(ctx).create(
+            {
+                "payment_date": time.strftime("%Y") + "-12-28",
+                "journal_id": self.bank_journal_chf.id,
+                "payment_method_id": self.payment_method_manual_in.id,
+                "group_invoices": True,
+            }
+        )
+
+        vals = register.get_payments_vals()
+        self.assertEqual(len(vals), 1)
+        expected_vals = [
+            # ref, partner, invoice count, amount
+            # 2 invoices grouped in one payment
+            ("INV1 INV2", self.supplier_iban.id, 2, 84.0)
+        ]
+        self.assertEqual(
+            [
+                (
+                    v["communication"],
+                    v["partner_id"],
+                    len(v["invoice_ids"][0][2]),
+                    v["amount"],
+                )
+                for v in sorted(
+                    vals, key=lambda i: (i["communication"], i["partner_id"])
+                )
+            ],
+            expected_vals,
+        )
+
+    def test_payment_non_isr_single_supplier(self):
+        """Test no grouping of non ISR on a single partner
+
+        Automatic grouping on free ref applies
+
+        """
+        invoices = self.create_supplier_invoice(
+            self.supplier_iban, "INV1"
+        ) | self.create_supplier_invoice(self.supplier_iban, "INV2")
+        # create an invoice where ref is set instead of invoice_payment_ref
+        PaymentRegister = self.env["account.register.payments"]
+        ctx = {"active_model": "account.invoice", "active_ids": invoices.ids}
+        register = PaymentRegister.with_context(ctx).create(
+            {
+                "payment_date": time.strftime("%Y") + "-12-28",
+                "journal_id": self.bank_journal_chf.id,
+                "payment_method_id": self.payment_method_manual_in.id,
+                "group_invoices": False,
+            }
+        )
+
+        vals = register.get_payments_vals()
+        self.assertEqual(len(vals), 1)
+        expected_vals = [
+            # ref, partner, invoice count, amount
+            # 2 invoices grouped
+            ("INV2", self.supplier_iban.id, 2, 84.0),
+        ]
+        self.assertEqual(
+            [
+                (
+                    v["communication"],
+                    v["partner_id"],
+                    len(v["invoice_ids"][0][2]),
+                    v["amount"],
+                )
+                for v in sorted(
+                    vals, key=lambda i: (i["communication"], i["partner_id"])
+                )
+            ],
+            expected_vals,
+        )


### PR DESCRIPTION
Use model account.move instead of account.invoice
Adapt tests
- in v12 it is made possible to use several time the same supplier
reference as the unicity has been dropped, this module will group
those in case of ISR.