### PR TITLE
[FIX] l10n_ch_qr_bill: duplicated bank field

### DIFF
--- a/l10n_ch_qr_bill/views/account_invoice_view.xml
+++ b/l10n_ch_qr_bill/views/account_invoice_view.xml
@@ -12,8 +12,9 @@
                     <field name="l10n_ch_currency_name" invisible="1" readonly="1"/>
                 </xpath>
 
-                <xpath expr="//page[@name='other_info']//field[@name='name']" position="after">
-                    <field name="partner_bank_id" attrs="{'readonly': [('state', 'not in', ['draft', 'open'])]}"/>
+                <xpath expr="//page[@name='other_info']//field[@name='partner_bank_id']" position="attributes">
+                    <attribute name="attrs">{'readonly': [('state', 'not in', ['draft', 'open'])]}</attribute>
+                    <attribute name="invisible">0</attribute>
                 </xpath>
 
                 <xpath expr="//button[@name='%(account.action_account_invoice_payment)d']" position="before">


### PR DESCRIPTION
partner_bank_id field is already present on the form but invisible. Change the visibility attribute instead of re-creating it