### PR TITLE
[10.0][BACKPORT] l10n_ch_qriban and include it in l10n_ch_qr_bill

### DIFF
--- a/l10n_ch_qr_bill/__manifest__.py
+++ b/l10n_ch_qr_bill/__manifest__.py
@@ -15,6 +15,7 @@
     'data': [
         'data/paperformat.xml',
         'views/account_invoice_view.xml',
+        'views/res_bank.xml',
         'report/swissqr_report.xml',
     ],
     'auto_install': False,

--- a/l10n_ch_qr_bill/models/res_bank.py
+++ b/l10n_ch_qr_bill/models/res_bank.py
@@ -4,28 +4,71 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 import re
 
-from odoo import models
+from odoo import api, fields, models, _
+from odoo.addons.base_iban.models.res_partner_bank import (
+    normalize_iban, pretty_iban, validate_iban
+)
+from odoo.addons.base.res.res_bank import sanitize_account_number
+from odoo.exceptions import ValidationError
 
 
 class ResPartnerBank(models.Model):
     _inherit = 'res.partner.bank'
+
+    l10n_ch_qr_iban = fields.Char(
+        string='QR-IBAN',
+        help=(
+            "Put the QR-IBAN here for your own bank accounts.  That way, you"
+            " can still use the main IBAN in the Account Number while you will"
+            " see the QR-IBAN for the barcode."
+        )
+    )
+
+    def _check_qr_iban_range(self, iban):
+        if not iban or len(iban) < 9:
+            return False
+        iid_start_index = 4
+        iid_end_index = 8
+        iid = iban[iid_start_index : iid_end_index + 1]
+        # Those iid between 30000 and 31999 are reserved for QR-IBANs only
+        return (re.match(r'\d+', iid)
+                and 30000 <= int(iid) <= 31999)
+
+    def _validate_qr_iban(self, qr_iban):
+        # Check first if it's a valid IBAN.
+        validate_iban(qr_iban)
+        # We sanitize first so that _check_qr_iban_range()
+        # can extract correct IID from IBAN to validate it.
+        sanitized_qr_iban = sanitize_account_number(qr_iban)
+        # Now, check if it's valid QR-IBAN (based on its IID).
+        if not self._check_qr_iban_range(sanitized_qr_iban):
+            raise ValidationError(_("QR-IBAN '%s' is invalid.") % qr_iban)
+        return True
+
+    @api.model
+    def create(self, vals):
+        if vals.get('l10n_ch_qr_iban'):
+            self._validate_qr_iban(vals['l10n_ch_qr_iban'])
+            iban = pretty_iban(normalize_iban(vals['l10n_ch_qr_iban']))
+            vals['l10n_ch_qr_iban'] = iban
+        return super(ResPartnerBank, self).create(vals)
+
+    def write(self, vals):
+        if vals.get('l10n_ch_qr_iban'):
+            self._validate_qr_iban(vals['l10n_ch_qr_iban'])
+            iban = pretty_iban(normalize_iban(vals['l10n_ch_qr_iban']))
+            vals['l10n_ch_qr_iban'] = iban
+        return super(ResPartnerBank, self).write(vals)
 
     def _is_qr_iban(self):
         """ Tells whether or not this bank account has a QR-IBAN account number.
         QR-IBANs are specific identifiers used in Switzerland as references in
         QR-codes. They are formed like regular IBANs, but are actually something
         different.
+
         """
-        if not self:
-            return False
-
-        self.ensure_one()
-
-        iid_start_index = 4
-        iid_end_index = 8
-        iid = self.sanitized_acc_number[iid_start_index : iid_end_index + 1]
         return (
-            self.acc_type == 'iban'
-            and re.match(r'\d+', iid)
-            and 30000 <= int(iid) <= 31999
-        )  # Those values for iid are reserved for QR-IBANs only
+            self.acc_type == "iban"
+            and self._check_qr_iban_range(self.sanitized_acc_number)
+            or self.l10n_ch_qr_iban
+        )

--- a/l10n_ch_qr_bill/report/swissqr_report.xml
+++ b/l10n_ch_qr_bill/report/swissqr_report.xml
@@ -45,7 +45,8 @@
                             <div id="receipt_indication_zone" class="swissqr_column_left receipt_indication_zone">
                                 <div class="swissqr_text">
                                   <span class="title">Account / Payable to</span><br/>
-                                  <span class="content" t-field="o.partner_bank_id.acc_number"/><br/>
+                                  <span class="content" t-field="o.partner_bank_id.acc_number" t-if="not o.partner_bank_id.l10n_ch_qr_iban"/>
+                                  <span class="content" t-field="o.partner_bank_id.l10n_ch_qr_iban" t-if="o.partner_bank_id.l10n_ch_qr_iban"/><br/>
                                   <span class="content" t-field="o.company_id.name"/><br/>
                                   <span class="content" t-field="o.company_id.street"/><br/>
                                   <span class="content" t-field="o.company_id.country_id.code"/>
@@ -102,7 +103,8 @@
                             <div id="indications_zone" class="swissqr_column_right indication_zone">
                                 <div class="swissqr_text">
                                     <span class="title">Account / Payable to</span><br/>
-                                    <span class="content" t-field="o.partner_bank_id.acc_number"/><br/>
+                                    <span class="content" t-field="o.partner_bank_id.acc_number" t-if="not o.partner_bank_id.l10n_ch_qr_iban"/>
+                                    <span class="content" t-field="o.partner_bank_id.l10n_ch_qr_iban" t-if="o.partner_bank_id.l10n_ch_qr_iban"/><br/>
                                     <span class="content" t-field="o.company_id.name"/><br/>
                                     <span class="content" t-field="o.company_id.street"/><br/>
                                     <span class="content" t-field="o.company_id.country_id.code"/>

--- a/l10n_ch_qr_bill/views/res_bank.xml
+++ b/l10n_ch_qr_bill/views/res_bank.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_partner_bank_form" model="ir.ui.view">
+        <field name="name">l10n_ch_qr.res.partner.bank.form</field>
+        <field name="model">res.partner.bank</field>
+        <field name="inherit_id" ref="base.view_partner_bank_form"/>
+        <field name="arch" type="xml">
+            <field name="acc_number" position="after">
+                <field name="l10n_ch_qr_iban"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
On version 13.0 following on support ticket Odoo added the module `l10n_ch_qriban`

This adds a field on `res.partner.bank` to store an QR-IBAN beside an IBAN.
QR-IBAN can be considered as aliases for IBAN with the sole purpose of being used with QRR.

This change in data model allows to have both information in order to do the reconciliation later using a single journal.