### PR TITLE
[12.0] Fix detection of QR-IBAN bank account in ref check

### DIFF
--- a/l10n_ch_base_bank/models/invoice.py
+++ b/l10n_ch_base_bank/models/invoice.py
@@ -67,7 +67,7 @@ class AccountInvoice(models.Model):
                           " type, you can set it manually or set appropriate"
                           " payment mode.")
                     )
-                if (bank_acc.acc_type != 'qr-iban'
+                if (not bank_acc._is_qr_iban()
                         and (invoice.currency_id.name == 'CHF'
                              and not bank_acc.l10n_ch_isr_subscription_chf)
                         or (invoice.currency_id.name == 'EUR'


### PR DESCRIPTION
`_is_qr_iban()` is prefered to check the type of account. And it is extensible, which allow to add the `l10n_ch_qriban` backport.