### PR TITLE
[12.0] l10n_ch_payment_slip hide core "ISR Print" button

### DIFF
--- a/l10n_ch_payment_slip/views/account_invoice.xml
+++ b/l10n_ch_payment_slip/views/account_invoice.xml
@@ -16,6 +16,7 @@
       <field name="arch" type="xml">
         <xpath expr="//button[@name='isr_print']" position="attributes">
           <attribute name="invisible">1</attribute>
+          <attribute name="attrs"/>
         </xpath>
         <xpath expr="//button[@name='action_invoice_sent']" position="after">
           <button type="object"


### PR DESCRIPTION
"ISR Print" core button is not hidden properly because invisible attribute is set from attrs="{invisible..." so we have to remove attrs attribute to make it really invisible.