### PR TITLE
[13.0][ADD] ebill_paynet_account_financial_discount

### DIFF
--- a/ebill_paynet_account_financial_discount/__init__.py
+++ b/ebill_paynet_account_financial_discount/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/ebill_paynet_account_financial_discount/__manifest__.py
+++ b/ebill_paynet_account_financial_discount/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "eBill Paynet Account Financial Discount",
+    "summary": """Handle discount in Paynet XML message.""",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/l10n-switzerland",
+    "depends": ["account_financial_discount", "ebill_paynet"],
+    "auto_install": True,
+}

--- a/ebill_paynet_account_financial_discount/messages/discount-2003A.xml.jinja
+++ b/ebill_paynet_account_financial_discount/messages/discount-2003A.xml.jinja
@@ -1,0 +1,8 @@
+{%- if discount %}
+<DISCOUNT Terms-Type="22">
+  <Discount-Percentage>{{ discount.percentage|round(2) }}</Discount-Percentage>
+  <TERMS>
+    <Payment-Period Type="CD" On-Or-After="3" Reference-Day="5">{{ discount.days }}</Payment-Period>
+  </TERMS>
+</DISCOUNT>
+{%- endif %}

--- a/ebill_paynet_account_financial_discount/models/__init__.py
+++ b/ebill_paynet_account_financial_discount/models/__init__.py
@@ -1,0 +1,1 @@
+from . import paynet_invoice_message

--- a/ebill_paynet_account_financial_discount/models/paynet_invoice_message.py
+++ b/ebill_paynet_account_financial_discount/models/paynet_invoice_message.py
@@ -1,0 +1,32 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import os
+
+from odoo import models
+from odoo.modules.module import get_module_root
+
+MODULE_PATH = get_module_root(os.path.dirname(__file__))
+DISCOUNT_TEMPLATE = "discount-2003A.xml.jinja"
+TEMPLATE_DIR = [MODULE_PATH + "/messages"]
+
+
+class PaynetInvoiceMessage(models.Model):
+    _inherit = "paynet.invoice.message"
+
+    def _get_jinja_env(self, template_dir):
+        template_dir += TEMPLATE_DIR
+        return super()._get_jinja_env(template_dir)
+
+    def _get_payload_params(self):
+        params = super()._get_payload_params()
+        params["discount_template"] = DISCOUNT_TEMPLATE
+        discount = {}
+        if self.invoice_id.invoice_payment_term_id.percent_discount:
+            terms = self.invoice_id.invoice_payment_term_id
+            discount = {
+                "percentage": terms.percent_discount,
+                "days": terms.days_discount,
+            }
+        params["discount"] = discount
+        return params

--- a/ebill_paynet_account_financial_discount/readme/CONTRIBUTORS.rst
+++ b/ebill_paynet_account_financial_discount/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/ebill_paynet_account_financial_discount/readme/DESCRIPTION.rst
+++ b/ebill_paynet_account_financial_discount/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This module implements the discount information in the payment terms node of the Paynet message.
+In regards to the module `account_financial_discount`.
+
+When the discount information is present in the payment terms of an invoice, they
+will automatically be included in the payment term of the Paynet message.

--- a/ebill_paynet_account_financial_discount/tests/__init__.py
+++ b/ebill_paynet_account_financial_discount/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_ebill_paynet_account_financial_discount

--- a/ebill_paynet_account_financial_discount/tests/examples/invoice_b2b.xml
+++ b/ebill_paynet_account_financial_discount/tests/examples/invoice_b2b.xml
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE XML-FSCM-INVOICE-2003A SYSTEM "XML-FSCM-INVOICE-2003A.DTD">
+<XML-FSCM-INVOICE-2003A>
+  <INTERCHANGE>
+    <IC-SENDER>
+      <Pid>52110726772852593</Pid>
+    </IC-SENDER>
+    <IC-RECEIVER>
+      <Pid>41010106799303734</Pid>
+    </IC-RECEIVER>
+    <IC-Ref>$IC_REF</IC-Ref>
+  </INTERCHANGE>
+  <INVOICE Type="EFD">
+    <HEADER>
+      <FUNCTION-FLAGS>
+        <Confirmation-Flag/>
+      </FUNCTION-FLAGS>
+      <MESSAGE-REFERENCE>
+        <REFERENCE-DATE>
+          <Reference-No>INV_TEST_01</Reference-No>
+          <Date Format="CCYYMMDD">20190621</Date>
+        </REFERENCE-DATE>
+      </MESSAGE-REFERENCE>
+      <PRINT-DATE>
+        <Date Format="CCYYMMDD">20190621</Date>
+      </PRINT-DATE>
+      <DELIVERY-DATE>
+        <Date Format="CCYYMMDD">20190621</Date>
+      </DELIVERY-DATE>
+      <REFERENCE>
+        <INVOICE-REFERENCE>
+          <REFERENCE-DATE>
+            <Reference-No>INV_TEST_01</Reference-No>
+            <Date Format="CCYYMMDD">20190621</Date>
+          </REFERENCE-DATE>
+        </INVOICE-REFERENCE>
+        <ORDER>
+          <REFERENCE-DATE>
+            <Reference-No>CustomerRef</Reference-No>
+            <Date Format="CCYYMMDD">20190601</Date>
+          </REFERENCE-DATE>
+        </ORDER>
+        <!-- <DELIVERY-NOTE> -->
+        <!--   <REFERENCE-DATE> -->
+        <!--     <Reference-No>93078415</Reference-No> -->
+        <!--     <Date Format="CCYYMMDD">20190620</Date> -->
+        <!--   </REFERENCE-DATE> -->
+        <!-- </DELIVERY-NOTE> -->
+        <!-- <OTHER-REFERENCE Type="SS"> -->
+        <!--   <REFERENCE-DATE> -->
+        <!--     <Reference-No>Brigitta Harati</Reference-No> -->
+        <!--   </REFERENCE-DATE> -->
+        <!-- </OTHER-REFERENCE> -->
+        <!-- <OTHER-REFERENCE Type="CR"> -->
+        <!--   <REFERENCE-DATE> -->
+        <!--     <Reference-No>Camile STECHMANN</Reference-No> -->
+        <!--   </REFERENCE-DATE> -->
+        <!-- </OTHER-REFERENCE> -->
+        <!-- <OTHER-REFERENCE Type="IT"> -->
+        <!--   <REFERENCE-DATE> -->
+        <!--     <Reference-No>432840</Reference-No> -->
+        <!--   </REFERENCE-DATE> -->
+        <!-- </OTHER-REFERENCE> -->
+      </REFERENCE>
+      <BILLER>
+        <Tax-No>CHE-012.345.678</Tax-No>
+        <Doc-Reference Type="QRR">1234567890</Doc-Reference>
+        <PARTY-ID>
+          <Pid>52110726772852593</Pid>
+        </PARTY-ID>
+        <NAME-ADDRESS Format="COM">
+          <NAME>
+            <Line-35>Camptocamp SA</Line-35>
+          </NAME>
+          <STREET>
+            <Line-35>StreetOne</Line-35>
+          </STREET>
+          <City>Lausanne</City>
+          <Zip>1015</Zip>
+          <Country>CH</Country>
+        </NAME-ADDRESS>
+        <BANK-INFO>
+          <Acct-No>CH2130808001234567827</Acct-No>
+          <BankId Type="IID" Country="CH">30808</BankId>
+        </BANK-INFO>
+      </BILLER>
+      <PAYER>
+        <PARTY-ID>
+          <Pid>41010198248040391</Pid>
+        </PARTY-ID>
+        <NAME-ADDRESS Format="COM">
+          <NAME>
+            <Line-35>Test RAD Customer XML</Line-35>
+          </NAME>
+          <STREET>
+            <Line-35>Teststrasse 100</Line-35>
+            <Line-35>This is a very long street name tha</Line-35>
+          </STREET>
+          <City>Fribourg</City>
+          <Zip>1700</Zip>
+          <Country>CH</Country>
+        </NAME-ADDRESS>
+      </PAYER>
+      <DELIVERY-PARTY>
+        <NAME-ADDRESS Format="COM">
+          <NAME>
+            <Line-35>Test RAD Customer XML</Line-35>
+            <Line-35>The Shed in the yard</Line-35>
+          </NAME>
+          <STREET>
+            <Line-35>Teststrasse 102</Line-35>
+          </STREET>
+          <City>Fribourg</City>
+          <Zip>1700</Zip>
+          <Country>CH</Country>
+        </NAME-ADDRESS>
+      </DELIVERY-PARTY>
+      <!-- <ALLOWANCE-OR-CHARGE Type="C"> -->
+      <!--   <Service-Code Type="FC"/> -->
+      <!--   <SERVICE-TEXT> -->
+      <!--     <Line-35>Porto + Verpackung</Line-35> -->
+      <!--   </SERVICE-TEXT> -->
+      <!--   <ALC-AMOUNT Print-Status="25"> -->
+      <!--     <Amount Currency="CHF">9.70</Amount> -->
+      <!--   </ALC-AMOUNT> -->
+      <!--   <TAX> -->
+      <!--     <Rate Category="S">7.70</Rate> -->
+      <!--     <Amount Currency="CHF">0.75</Amount> -->
+      <!--   </TAX> -->
+      <!-- </ALLOWANCE-OR-CHARGE> -->
+    </HEADER>
+    <LINE-ITEM Line-Number="1">
+      <ITEM-ID>
+        <Item-Id Type="VN">370003021</Item-Id>
+        <Item-Id Type="SA">370003021</Item-Id>
+      </ITEM-ID>
+      <ITEM-DESCRIPTION>
+        <Item-Type-Code>1011</Item-Type-Code>
+        <Line-35>Product One</Line-35>
+      </ITEM-DESCRIPTION>
+      <ITEM-REFERENCE Type="ON">
+      <!-- TODO add linked sale order in test -->
+        <REFERENCE-DATE>
+          <Reference-No>CustomerRef</Reference-No>
+          <Date Format="CCYYMMDD">20190601</Date>
+          <!-- <Line-No>1</Line-No> -->
+        </REFERENCE-DATE>
+      </ITEM-REFERENCE>
+      <Quantity Type="47" Units="PCE">4.0</Quantity>
+      <Price Type="YYY">492.0</Price>
+      <Price Type="AAA">492.0</Price>
+      <Price Type="XXX">529.88</Price>
+      <ITEM-AMOUNT Type="66">
+        <Amount Currency="CHF">529.88</Amount>
+      </ITEM-AMOUNT>
+      <TAX>
+        <Rate>7.7</Rate>
+        <Amount Currency="CHF">37.88</Amount>
+      </TAX>
+    </LINE-ITEM>
+    <LINE-ITEM Line-Number="2">
+      <ITEM-ID>
+        <Item-Id Type="VN">370003022</Item-Id>
+        <Item-Id Type="SA">370003022</Item-Id>
+      </ITEM-ID>
+      <ITEM-DESCRIPTION>
+        <Item-Type-Code>1011</Item-Type-Code>
+        <Line-35>Product With a Very Long Name That </Line-35>
+        <Line-35>Need To Be Truncated</Line-35>
+      </ITEM-DESCRIPTION>
+      <ITEM-REFERENCE Type="ON">
+      <!-- TODO add linked sale order in test -->
+        <REFERENCE-DATE>
+          <Reference-No>CustomerRef</Reference-No>
+          <Date Format="CCYYMMDD">20190601</Date>
+          <!-- <Line-No>1</Line-No> -->
+        </REFERENCE-DATE>
+      </ITEM-REFERENCE>
+      <Quantity Type="47" Units="PCE">1.0</Quantity>
+      <Price Type="YYY">0.0</Price>
+      <Price Type="AAA">0.0</Price>
+      <Price Type="XXX">0.0</Price>
+      <ITEM-AMOUNT Type="66">
+        <Amount Currency="CHF">0.0</Amount>
+      </ITEM-AMOUNT>
+      <TAX>
+        <Rate>7.7</Rate>
+        <Amount Currency="CHF">0.0</Amount>
+      </TAX>
+    </LINE-ITEM>
+    <LINE-ITEM Line-Number="3">
+      <ITEM-DESCRIPTION>
+        <Item-Type-Code>1011</Item-Type-Code>
+        <Line-35>Phone support</Line-35>
+      </ITEM-DESCRIPTION>
+      <ITEM-REFERENCE Type="ON">
+      <!-- TODO add linked sale order in test -->
+        <REFERENCE-DATE>
+          <Reference-No>CustomerRef</Reference-No>
+          <Date Format="CCYYMMDD">20190601</Date>
+          <!-- <Line-No>1</Line-No> -->
+        </REFERENCE-DATE>
+      </ITEM-REFERENCE>
+      <Quantity Type="47" Units="PCE">4.0</Quantity>
+      <Price Type="YYY">0.0</Price>
+      <Price Type="AAA">0.0</Price>
+      <Price Type="XXX">0.0</Price>
+      <ITEM-AMOUNT Type="66">
+        <Amount Currency="CHF">0.0</Amount>
+      </ITEM-AMOUNT>
+      <TAX>
+        <Rate>0</Rate>
+      </TAX>
+    </LINE-ITEM>
+    <SUMMARY>
+      <INVOICE-AMOUNT Print-Status="25">
+        <Amount Currency="CHF">529.88</Amount>
+      </INVOICE-AMOUNT>
+      <VAT-AMOUNT Print-Status="25">
+        <!-- Should it not be the amount to be taxed ? -->
+        <Amount Currency="CHF">37.88</Amount>
+      </VAT-AMOUNT>
+      <TAX>
+        <TAX-BASIS>
+          <Amount Currency="CHF">492.0</Amount>
+        </TAX-BASIS>
+        <Rate Category="S">7.7</Rate>
+        <Amount Currency="CHF">37.88</Amount>
+      </TAX>
+      <PAYMENT-TERMS>
+        <BASIC Payment-Type="QR" Terms-Type="5">
+          <TERMS>
+            <Date>20190820</Date>
+          </TERMS>
+        </BASIC>
+        <DISCOUNT Terms-Type="22">
+          <Discount-Percentage>2.0</Discount-Percentage>
+          <TERMS>
+            <Payment-Period Type="CD" On-Or-After="3" Reference-Day="5">10</Payment-Period>
+          </TERMS>
+        </DISCOUNT>
+      </PAYMENT-TERMS>
+    </SUMMARY>
+  </INVOICE>
+</XML-FSCM-INVOICE-2003A>

--- a/ebill_paynet_account_financial_discount/tests/test_ebill_paynet_account_financial_discount.py
+++ b/ebill_paynet_account_financial_discount/tests/test_ebill_paynet_account_financial_discount.py
@@ -1,0 +1,68 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from string import Template
+
+from freezegun import freeze_time
+
+from odoo.tools import file_open
+
+from ...ebill_paynet.tests.common import CommonCase
+
+
+@freeze_time("2019-06-21 09:06:00")
+class TestEbillPaynetAccountFinancialDiscount(CommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.payment_term = cls.env["account.payment.term"].create(
+            {
+                "name": "Skonto",
+                "days_discount": 10,
+                "percent_discount": 2.0,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "value": "balance",
+                            "days": 60,
+                            "option": "day_after_invoice_date",
+                        },
+                    )
+                ],
+            }
+        )
+
+    def test_invoice(self):
+        """ Check XML payload genetated for an invoice."""
+        self.invoice.name = "INV_TEST_01"
+        self.invoice.invoice_date_due = "2019-07-01"
+        self.invoice.invoice_payment_term_id = self.payment_term
+        message = self.invoice.create_paynet_message()
+        message.payload = message._generate_payload()
+        # Remove the PDF file data from the XML to ease testing
+        lines = message.payload.splitlines()
+        for pos, line in enumerate(lines):
+            if line.find("Back-Pack") != -1:
+                lines.pop(pos)
+                break
+        payload = "\n".join(lines).encode("utf8")
+        self.assertXmlDocument(payload)
+        # Prepare the XML file that is expected
+        expected_tmpl = Template(
+            file_open(
+                "ebill_paynet_account_financial_discount/tests/examples/invoice_b2b.xml"
+            ).read()
+        )
+        expected = expected_tmpl.substitute(IC_REF=message.ic_ref).encode("utf8")
+        # Remove the comments in the expected xml
+        expected_nocomment = [
+            line
+            for line in expected.split(b"\n")
+            if not line.lstrip().startswith(b"<!--")
+        ]
+        expected_nocomment = b"\n".join(expected_nocomment)
+        self.assertFalse(self.compare_xml_line_by_line(payload, expected_nocomment))
+        self.assertXmlEquivalentOutputs(payload, expected_nocomment)

--- a/setup/ebill_paynet_account_financial_discount/odoo/addons/ebill_paynet_account_financial_discount
+++ b/setup/ebill_paynet_account_financial_discount/odoo/addons/ebill_paynet_account_financial_discount
@@ -1,0 +1,1 @@
+../../../../ebill_paynet_account_financial_discount

--- a/setup/ebill_paynet_account_financial_discount/setup.py
+++ b/setup/ebill_paynet_account_financial_discount/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Depends on
- [ ] https://github.com/OCA/account-financial-tools/pull/1040

This module implements the discount information in the payment terms node
of the Paynet message. In regards to the module `account_financial_discount`.

When the discount information is present in the payment terms of an invoice, they
will automatically be included in the payment term of the Paynet message.

This module was included in #551 and already reviewed there. But to ease work it is now proposed on its own.