### PR TITLE
[13][ADD] ebill_paynet_customer_free_ref

### DIFF
--- a/ebill_paynet_customer_free_ref/__init__.py
+++ b/ebill_paynet_customer_free_ref/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/ebill_paynet_customer_free_ref/__manifest__.py
+++ b/ebill_paynet_customer_free_ref/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "eBill Paynet Customer Free Reference",
+    "summary": "Glue module: ebill_paynet and sale_order_customer_free_ref",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/l10n-switzerland",
+    "depends": ["ebill_paynet", "sale_order_customer_free_ref"],
+    "auto_install": True,
+}

--- a/ebill_paynet_customer_free_ref/models/__init__.py
+++ b/ebill_paynet_customer_free_ref/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move
+from . import sale_order

--- a/ebill_paynet_customer_free_ref/models/account_move.py
+++ b/ebill_paynet_customer_free_ref/models/account_move.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def get_paynet_other_reference(self):
+        ref = super().get_paynet_other_reference()
+        for order in self.invoice_line_ids.sale_line_ids.mapped("order_id"):
+            if order.customer_order_free_ref:
+                ref.append({"type": "CR", "no": order.customer_order_free_ref})
+        return ref

--- a/ebill_paynet_customer_free_ref/models/sale_order.py
+++ b/ebill_paynet_customer_free_ref/models/sale_order.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class SaleOrder(models.Model):
+
+    _inherit = "sale.order"
+
+    @api.depends("customer_order_number")
+    def _compute_paynet_client_order_ref(self):
+        for order in self:
+            order.paynet_client_order_ref = order.customer_order_number

--- a/ebill_paynet_customer_free_ref/readme/CONTRIBUTORS.rst
+++ b/ebill_paynet_customer_free_ref/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/ebill_paynet_customer_free_ref/readme/DESCRIPTION.rst
+++ b/ebill_paynet_customer_free_ref/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module interconnects the `sale_order_customer_free_ref` from EDI with the `ebill_paynet` module.
+
+The order reference in the XML messge is set with the `customer_order_number` field.
+And the `customer_order_free_ref` is added as a <OTHER-REFERENCE> node.

--- a/ebill_paynet_customer_free_ref/tests/__init__.py
+++ b/ebill_paynet_customer_free_ref/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_ebill_paynet_customer_free_ref

--- a/ebill_paynet_customer_free_ref/tests/examples/invoice_b2b.xml
+++ b/ebill_paynet_customer_free_ref/tests/examples/invoice_b2b.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE XML-FSCM-INVOICE-2003A SYSTEM "XML-FSCM-INVOICE-2003A.DTD">
+<XML-FSCM-INVOICE-2003A>
+  <INTERCHANGE>
+    <IC-SENDER>
+      <Pid>52110726772852593</Pid>
+    </IC-SENDER>
+    <IC-RECEIVER>
+      <Pid>41010106799303734</Pid>
+    </IC-RECEIVER>
+    <IC-Ref>$IC_REF</IC-Ref>
+  </INTERCHANGE>
+  <INVOICE Type="EFD">
+    <HEADER>
+      <FUNCTION-FLAGS>
+        <Confirmation-Flag/>
+      </FUNCTION-FLAGS>
+      <MESSAGE-REFERENCE>
+        <REFERENCE-DATE>
+          <Reference-No>INV_TEST_01</Reference-No>
+          <Date Format="CCYYMMDD">20190621</Date>
+        </REFERENCE-DATE>
+      </MESSAGE-REFERENCE>
+      <PRINT-DATE>
+        <Date Format="CCYYMMDD">20190621</Date>
+      </PRINT-DATE>
+      <DELIVERY-DATE>
+        <Date Format="CCYYMMDD">20190621</Date>
+      </DELIVERY-DATE>
+      <REFERENCE>
+        <INVOICE-REFERENCE>
+          <REFERENCE-DATE>
+            <Reference-No>INV_TEST_01</Reference-No>
+            <Date Format="CCYYMMDD">20190621</Date>
+          </REFERENCE-DATE>
+        </INVOICE-REFERENCE>
+        <ORDER>
+          <REFERENCE-DATE>
+            <Reference-No>888</Reference-No>
+            <Date Format="CCYYMMDD">20190601</Date>
+          </REFERENCE-DATE>
+        </ORDER>
+        <DELIVERY-NOTE>
+          <REFERENCE-DATE>
+            <Reference-No>track_me_if_you_can</Reference-No>
+            <!-- <Date Format="CCYYMMDD">20190620</Date> -->
+          </REFERENCE-DATE>
+        </DELIVERY-NOTE>
+        <OTHER-REFERENCE Type="CR">
+          <REFERENCE-DATE>
+            <Reference-No>FREE</Reference-No>
+          </REFERENCE-DATE>
+        </OTHER-REFERENCE>
+      </REFERENCE>
+      <BILLER>
+        <Tax-No>CHE-012.345.678</Tax-No>
+        <Doc-Reference Type="QRR">1234567890</Doc-Reference>
+        <PARTY-ID>
+          <Pid>52110726772852593</Pid>
+        </PARTY-ID>
+        <NAME-ADDRESS Format="COM">
+          <NAME>
+            <Line-35>Camptocamp SA</Line-35>
+          </NAME>
+          <STREET>
+            <Line-35>StreetOne</Line-35>
+          </STREET>
+          <City>Lausanne</City>
+          <Zip>1015</Zip>
+          <Country>CH</Country>
+        </NAME-ADDRESS>
+        <BANK-INFO>
+          <Acct-No>CH2130808001234567827</Acct-No>
+          <BankId Type="IID" Country="CH">30808</BankId>
+        </BANK-INFO>
+      </BILLER>
+      <PAYER>
+        <PARTY-ID>
+          <Pid>41010198248040391</Pid>
+        </PARTY-ID>
+        <NAME-ADDRESS Format="COM">
+          <NAME>
+            <Line-35>Test RAD Customer XML</Line-35>
+          </NAME>
+          <STREET>
+            <Line-35>Teststrasse 100</Line-35>
+            <Line-35>This is a very long street name tha</Line-35>
+          </STREET>
+          <City>Fribourg</City>
+          <Zip>1700</Zip>
+          <Country>CH</Country>
+        </NAME-ADDRESS>
+      </PAYER>
+      <DELIVERY-PARTY>
+        <NAME-ADDRESS Format="COM">
+          <NAME>
+            <Line-35>Test RAD Customer XML</Line-35>
+            <Line-35>The Shed in the yard</Line-35>
+          </NAME>
+          <STREET>
+            <Line-35>Teststrasse 102</Line-35>
+          </STREET>
+          <City>Fribourg</City>
+          <Zip>1700</Zip>
+          <Country>CH</Country>
+        </NAME-ADDRESS>
+      </DELIVERY-PARTY>
+    </HEADER>
+    <LINE-ITEM Line-Number="1">
+      <ITEM-ID>
+        <Item-Id Type="VN">370003021</Item-Id>
+        <Item-Id Type="SA">370003021</Item-Id>
+      </ITEM-ID>
+      <ITEM-DESCRIPTION>
+        <Item-Type-Code>1011</Item-Type-Code>
+        <Line-35>Product One</Line-35>
+      </ITEM-DESCRIPTION>
+      <ITEM-REFERENCE Type="ON">
+        <REFERENCE-DATE>
+          <Reference-No>888</Reference-No>
+          <Date Format="CCYYMMDD">20190601</Date>
+        </REFERENCE-DATE>
+      </ITEM-REFERENCE>
+      <Quantity Type="47" Units="PCE">4.0</Quantity>
+      <Price Type="YYY">492.0</Price>
+      <Price Type="AAA">492.0</Price>
+      <Price Type="XXX">529.88</Price>
+      <ITEM-AMOUNT Type="66">
+        <Amount Currency="CHF">492.0</Amount>
+      </ITEM-AMOUNT>
+      <TAX>
+        <Rate>7.7</Rate>
+        <Amount Currency="CHF">37.88</Amount>
+      </TAX>
+    </LINE-ITEM>
+    <LINE-ITEM Line-Number="2">
+      <ITEM-ID>
+        <Item-Id Type="VN">370003022</Item-Id>
+        <Item-Id Type="SA">370003022</Item-Id>
+      </ITEM-ID>
+      <ITEM-DESCRIPTION>
+        <Item-Type-Code>1011</Item-Type-Code>
+        <Line-35>Product With a Very Long Name That </Line-35>
+        <Line-35>Need To Be Truncated</Line-35>
+      </ITEM-DESCRIPTION>
+      <ITEM-REFERENCE Type="ON">
+        <REFERENCE-DATE>
+          <Reference-No>888</Reference-No>
+          <Date Format="CCYYMMDD">20190601</Date>
+        </REFERENCE-DATE>
+      </ITEM-REFERENCE>
+      <Quantity Type="47" Units="PCE">1.0</Quantity>
+      <Price Type="YYY">0.0</Price>
+      <Price Type="AAA">0.0</Price>
+      <Price Type="XXX">0.0</Price>
+      <ITEM-AMOUNT Type="66">
+        <Amount Currency="CHF">0.0</Amount>
+      </ITEM-AMOUNT>
+      <TAX>
+        <Rate>7.7</Rate>
+        <Amount Currency="CHF">0.0</Amount>
+      </TAX>
+    </LINE-ITEM>
+    <LINE-ITEM Line-Number="3">
+      <ITEM-DESCRIPTION>
+        <Item-Type-Code>1011</Item-Type-Code>
+        <Line-35>Phone support</Line-35>
+      </ITEM-DESCRIPTION>
+      <ITEM-REFERENCE Type="ON">
+        <REFERENCE-DATE>
+          <Reference-No>888</Reference-No>
+          <Date Format="CCYYMMDD">20190601</Date>
+        </REFERENCE-DATE>
+      </ITEM-REFERENCE>
+      <Quantity Type="47" Units="PCE">4.0</Quantity>
+      <Price Type="YYY">0.0</Price>
+      <Price Type="AAA">0.0</Price>
+      <Price Type="XXX">0.0</Price>
+      <ITEM-AMOUNT Type="66">
+        <Amount Currency="CHF">0.0</Amount>
+      </ITEM-AMOUNT>
+      <TAX>
+        <Rate>0</Rate>
+      </TAX>
+    </LINE-ITEM>
+    <SUMMARY>
+      <INVOICE-AMOUNT Print-Status="25">
+        <Amount Currency="CHF">529.88</Amount>
+      </INVOICE-AMOUNT>
+      <VAT-AMOUNT Print-Status="25">
+        <Amount Currency="CHF">37.88</Amount>
+      </VAT-AMOUNT>
+      <EXTENDED-AMOUNT Type="79">
+        <Amount Currency="CHF">492.0</Amount>
+      </EXTENDED-AMOUNT>
+      <TAX>
+        <TAX-BASIS>
+          <Amount Currency="CHF">492.0</Amount>
+        </TAX-BASIS>
+        <Rate Category="S">7.7</Rate>
+        <Amount Currency="CHF">37.88</Amount>
+      </TAX>
+      <PAYMENT-TERMS>
+        <BASIC Payment-Type="QR" Terms-Type="5">
+          <TERMS>
+            <Date>20190621</Date>
+          </TERMS>
+        </BASIC>
+      </PAYMENT-TERMS>
+    </SUMMARY>
+  </INVOICE>
+</XML-FSCM-INVOICE-2003A>

--- a/ebill_paynet_customer_free_ref/tests/test_ebill_paynet_customer_free_ref.py
+++ b/ebill_paynet_customer_free_ref/tests/test_ebill_paynet_customer_free_ref.py
@@ -1,0 +1,50 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from string import Template
+
+from freezegun import freeze_time
+
+from odoo.tools import file_open
+
+from ...ebill_paynet.tests.common import CommonCase
+
+
+@freeze_time("2019-06-21 09:06:00")
+class TestEbillPaynetCustomerFreeRef(CommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.invoice.name = "INV_TEST_01"
+        cls.sale.customer_order_number = "888"
+        cls.sale.customer_order_free_ref = "FREE"
+
+    def test_invoice(self):
+        """ Check XML payload genetated for an invoice."""
+        message = self.invoice.create_paynet_message()
+        message.payload = message._generate_payload()
+        # Remove the PDF file data from the XML to ease testing
+        lines = message.payload.splitlines()
+        for pos, line in enumerate(lines):
+            if line.find("Back-Pack") != -1:
+                lines.pop(pos)
+                break
+        payload = "\n".join(lines).encode("utf8")
+        self.assertXmlDocument(payload)
+        # Prepare the XML file that is expected
+        expected_tmpl = Template(
+            file_open(
+                "ebill_paynet_customer_free_ref/tests/examples/invoice_b2b.xml"
+            ).read()
+        )
+        expected = expected_tmpl.substitute(IC_REF=message.ic_ref).encode("utf8")
+        # Remove the comments in the expected xml
+        expected_nocomment = [
+            line
+            for line in expected.split(b"\n")
+            if not line.lstrip().startswith(b"<!--")
+        ]
+        expected_nocomment = b"\n".join(expected_nocomment)
+        self.assertFalse(self.compare_xml_line_by_line(payload, expected_nocomment))
+        self.assertXmlEquivalentOutputs(payload, expected_nocomment)

--- a/setup/ebill_paynet_customer_free_ref/odoo/addons/ebill_paynet_customer_free_ref
+++ b/setup/ebill_paynet_customer_free_ref/odoo/addons/ebill_paynet_customer_free_ref
@@ -1,0 +1,1 @@
+../../../../ebill_paynet_customer_free_ref

--- a/setup/ebill_paynet_customer_free_ref/setup.py
+++ b/setup/ebill_paynet_customer_free_ref/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module interconnects the `sale_order_customer_free_ref` from EDI
with the `ebill_paynet` module.

The order reference in the XML messge is set with the `customer_order_number` field.
And the `customer_order_free_ref` is added as a <OTHER-REFERENCE> node.