### PR TITLE
[11.0][FIX] l10n_ch_payment_slip: fix readme

### DIFF
--- a/l10n_ch_payment_slip/README.rst
+++ b/l10n_ch_payment_slip/README.rst
@@ -34,10 +34,9 @@ This is especialy useful when using pre-printed paper.
 Options also allow you to print the ISR in background when using
 white paper and printing customer address in the page header.
 
-By default address format on ISR is
-`%(street)s\n%(street2)s\n%(zip)s %(city)s`
-This can be change by setting System parameter
-`isr.address.format`
+The address format on ISR can be changed by setting System parameter
+`isr.address.format`.
+It supports the same format as country's field "Layout in Reports".
 
 
 Usage
@@ -105,4 +104,3 @@ mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
 To contribute to this module, please visit http://odoo-community.org.
-


### PR DESCRIPTION
The `\n` in the README.rst prevents odoo from synchronising translated terms. I simple removed it from the rst.