### PR TITLE
[12.0] Fix l10n_ch_base_bank account type calculation

### DIFF
--- a/l10n_ch_base_bank/models/bank.py
+++ b/l10n_ch_base_bank/models/bank.py
@@ -18,6 +18,16 @@ def validate_l10n_ch_postal(postal_acc_number):
     """
     if not postal_acc_number:
         raise ValidationError(_("There is no postal account number."))
+
+    # Account number was changed in _update_acc_name to have a structure like
+    # parner / acc_number. The goal is to avoid duplicated bank accounts
+    # https://github.com/OCA/l10n-switzerland/blob/a6f79e04d9d2e8c19f5592b5fe97
+    # 4be19c5f721f/l10n_ch_base_bank/models/bank.py#L289
+    # But with this change, the type of the account is not recognized as postal
+    # anymore. So we consider valid if  has substring /Postal number.
+    if "/Postal number" in postal_acc_number:
+        return
+
     if re.match('^[0-9]{2}-[0-9]{1,6}-[0-9]$', postal_acc_number):
         ref_subparts = postal_acc_number.split('-')
         postal_acc_number = (

--- a/l10n_ch_base_bank/tests/test_bank_type.py
+++ b/l10n_ch_base_bank/tests/test_bank_type.py
@@ -31,6 +31,13 @@ class TestBankType(common.SavepointCase):
             'acc_number': '01-1234-1',
         })
         self.assertEqual(bank_account.acc_type, 'postal')
+        bank_account = self.env['res.partner.bank'].create({
+            'partner_id': self.partner2.id,
+            'acc_number': "{}/Postal number 01-1234-1".format(
+                self.partner2.name
+            )
+        })
+        self.assertEqual(bank_account.acc_type, 'postal')
 
     @classmethod
     def setUpClass(cls):
@@ -38,3 +45,4 @@ class TestBankType(common.SavepointCase):
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.company = cls.env.ref('base.main_company')
         cls.partner = cls.env.ref('base.main_partner')
+        cls.partner2 = cls.env.ref('base.partner_admin')


### PR DESCRIPTION
Account number is changed in `_update_acc_name` to have a structure like `parner / Postal number acc_number`. 
https://github.com/OCA/l10n-switzerland/blob/a6f79e04d9d2e8c19f5592b5fe974be19c5f721f/l10n_ch_base_bank/models/bank.py#L289
The goal is to  avoid duplicated bank accounts. But with this change, the type of the account is not recognized as postal anymore. So we consider valid if has substring "/Postal number" is found in account number
