### PR TITLE
[8.0] l10n_ch_qr_bill: fixed missing QRR data in qr code

### DIFF
--- a/l10n_ch_qr_bill/i18n/it.po
+++ b/l10n_ch_qr_bill/i18n/it.po
@@ -1,16 +1,15 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* l10n_ch_qr_bill
+#	* l10n_ch_qr_bill
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-24 07:11+0000\n"
-"PO-Revision-Date: 2020-09-24 07:11+0000\n"
+"POT-Creation-Date: 2021-03-18 12:36+0000\n"
+"PO-Revision-Date: 2021-03-18 12:36+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -43,24 +42,14 @@ msgstr "Conti Bancari"
 
 #. module: l10n_ch_qr_bill
 #: help:account.invoice,l10n_ch_qrr_sent:0
-msgid ""
-"Boolean value telling whether or not the QRR corresponding to this invoice "
-"has already been printed or sent by mail."
-msgstr ""
-"Il flag indica se il QRR di questa fattura è già stato stampato o inviato "
-"per mail."
+msgid "Boolean value telling whether or not the QRR corresponding to this invoice has already been printed or sent by mail."
+msgstr "Il flag indica se il QRR di questa fattura è già stato stampato o inviato per mail."
 
 #. module: l10n_ch_qr_bill
-#: code:addons/l10n_ch_qr_bill/models/account_invoice.py:257
+#: code:addons/l10n_ch_qr_bill/models/account_invoice.py:256
 #, python-format
-msgid ""
-"Cannot generate the QR-bill. Please check you have configured the address of "
-"your company and debtor. If you are using a QR-IBAN, also check the "
-"invoice's payment reference is a QR reference."
-msgstr ""
-"Non è possibile creare una QR-Bill. Controllare che siano configurati gli "
-"indirizzi della company e del cliente. Se state usando un QR-IBAN, "
-"controllare anche che il tipo di riferimento di pagamento sia QRR."
+msgid "Cannot generate the QR-bill. Please check you have configured the address of your company and debtor. If you are using a QR-IBAN, also check the invoice's payment reference is a QR reference."
+msgstr "Non è possibile creare una QR-Bill. Controllare che siano configurati gli indirizzi della company e del cliente. Se state usando un QR-IBAN, controllare anche che il tipo di riferimento di pagamento sia QRR."
 
 #. module: l10n_ch_qr_bill
 #: view:website:l10n_ch_qr_bill.l10n_ch_swissqr_template
@@ -76,11 +65,6 @@ msgstr "Divisa"
 #: model:ir.model,name:l10n_ch_qr_bill.model_account_invoice
 msgid "Invoice"
 msgstr "Fattura"
-
-#. module: l10n_ch_qr_bill
-#: field:account.invoice,l10n_ch_qrr:0
-msgid "L10n ch qrr"
-msgstr "L10n ch qrr"
 
 #. module: l10n_ch_qr_bill
 #: field:account.invoice,l10n_ch_qrr_sent:0
@@ -118,6 +102,11 @@ msgid "QR-bill for invoice"
 msgstr "QR-Fattura n:"
 
 #. module: l10n_ch_qr_bill
+#: field:account.invoice,l10n_ch_qrr:0
+msgid "QRR ref"
+msgstr "QRR rif"
+
+#. module: l10n_ch_qr_bill
 #: view:website:l10n_ch_qr_bill.l10n_ch_swissqr_template
 msgid "Receipt"
 msgstr "Ricevuta"
@@ -129,12 +118,8 @@ msgstr "Riferimento"
 
 #. module: l10n_ch_qr_bill
 #: help:account.invoice,l10n_ch_qrr_spaced:0
-msgid ""
-"Reference QRR split in blocks of 5 characters (right-justified),to generate "
-"QR-bill report."
-msgstr ""
-"Reference QRR split in blocks of 5 characters (right-justified),to generate "
-"QR-bill report."
+msgid "Reference QRR split in blocks of 5 characters (right-justified),to generate QR-bill report."
+msgstr "Reference QRR split in blocks of 5 characters (right-justified),to generate QR-bill report."
 
 #. module: l10n_ch_qr_bill
 #: model:ir.model,name:l10n_ch_qr_bill.model_report
@@ -142,7 +127,7 @@ msgid "Report"
 msgstr "Report"
 
 #. module: l10n_ch_qr_bill
-#: code:addons/l10n_ch_qr_bill/models/account_invoice.py:49
+#: code:addons/l10n_ch_qr_bill/models/account_invoice.py:51
 #, python-format
 msgid "Swiss Reference QRR"
 msgstr "QRR Svizzera"
@@ -153,7 +138,7 @@ msgid "The name of this invoice's currency"
 msgstr "The name of this invoice's currency"
 
 #. module: l10n_ch_qr_bill
-#: code:addons/l10n_ch_qr_bill/models/account_invoice.py:279
+#: code:addons/l10n_ch_qr_bill/models/account_invoice.py:278
 #, python-format
 msgid "The payment reference is not a valid QR Reference."
 msgstr "Il riferimento di pagamento non ha un QR-riferimento valido."

--- a/l10n_ch_qr_bill/tests/test_swissqr.py
+++ b/l10n_ch_qr_bill/tests/test_swissqr.py
@@ -153,7 +153,7 @@ class TestSwissQR(HttpCase):
         # Let us test the generation of a SwissQR for an invoice, first by showing an
         # QR is included in the invoice is only generated when Odoo has all the data
         # it needs.
-        self.invoice1.action_invoice_open()
+        self.invoice1.invoice_validate()
         self.swissqr_not_generated(self.invoice1)
 
     def test_swissQR_iban(self):
@@ -161,7 +161,7 @@ class TestSwissQR(HttpCase):
         # Here we don't use a structured reference
         iban_account = self.create_account(CH_IBAN)
         self.invoice1.partner_bank_id = iban_account
-        self.invoice1.action_invoice_open()
+        self.invoice1.invoice_validate()
         self.swissqr_generated(self.invoice1, ref_type="NON")
 
     def test_swissQR_qriban(self):
@@ -169,5 +169,5 @@ class TestSwissQR(HttpCase):
         qriban_account = self.create_account(QR_IBAN)
         self.assertTrue(qriban_account._is_qr_iban())
         self.invoice1.partner_bank_id = qriban_account
-        self.invoice1.action_invoice_open()
+        self.invoice1.invoice_validate()
         self.swissqr_generated(self.invoice1, ref_type="QRR")

--- a/l10n_ch_qr_bill/views/account_invoice_view.xml
+++ b/l10n_ch_qr_bill/views/account_invoice_view.xml
@@ -12,6 +12,12 @@
                     <field name="l10n_ch_currency_name" invisible="1" readonly="1"/>
                 </xpath>
 
+                <field name="tax_line" position="before">
+                    <group colspan="4" attrs="{'invisible': [('l10n_ch_qrr', '=', False)]}">
+                        <field name="l10n_ch_qrr" colspan="4"/>
+                    </group>
+                </field>
+
                 <xpath expr="//field[@name='partner_bank_id']" position="attributes">
                     <attribute name="attrs">{'readonly': [('state', 'not in', ['draft', 'open'])]}</attribute>
                 </xpath>


### PR DESCRIPTION
probably during backporting of the module l10n_ch_qr_bill was keept the wrong account.invoice validate method, this causes a missing QRR reference inserted in QR code.

In this PR I removed dependency of field 'name' for QRR reference insertion in qr code, removing also unrequired account.invoice validate method.
