### PR TITLE
[10.0] l10n_ch_qr_bill: Fix _get_communications

### DIFF
--- a/l10n_ch_qr_bill/models/account_invoice.py
+++ b/l10n_ch_qr_bill/models/account_invoice.py
@@ -140,7 +140,8 @@ class AccountInvoice(models.Model):
             record.l10n_ch_qrr_spaced = spaced_qrr
 
     def _get_communications(self):
-        if self.has_qrr():
+        is_qrr = self.partner_bank_id._is_qr_iban()
+        if is_qrr:
             structured_communication = self.l10n_ch_qrr
             free_communication = ''
         else:
@@ -161,7 +162,7 @@ class AccountInvoice(models.Model):
         # just like ISR number for invoices)
         reference_type = 'NON'
         reference = ''
-        if self.has_qrr():
+        if is_qrr:
             # _check_for_qr_code_errors ensures we can't have a QR-IBAN
             # without a QR-reference here
             reference_type = 'QRR'


### PR DESCRIPTION
_get_communications function defines the reference and
reference_type to be used in the generation of the QR bill.

has_qrr only checks if the reference is defined in the name
field of account.invoice. But the reference is displayed on the
report if the bank account is set up for QR bill.

This allows to generate QR XML properly even if the
name field is empty on customer invoices.