### PR TITLE
[12.0]  l10n_ch_base_bank: Avoid breaking with =like and =ilike operators

### DIFF
--- a/l10n_ch_base_bank/models/invoice.py
+++ b/l10n_ch_base_bank/models/invoice.py
@@ -42,7 +42,7 @@ class AccountInvoice(models.Model):
             # add filtered operator to query
             query_op = ("SELECT id FROM account_invoice "
                         "WHERE REPLACE(reference, ' ', '') %s %%s" %
-                        (operator,))
+                        ({'=like': 'like', '=ilike': 'ilike'}.get(operator, operator),))
             # avoid pylint check on no-sql-injection query_op is safe
             query = query_op
             self.env.cr.execute(query, (value,))


### PR DESCRIPTION
=ilike and =like don't exist in sql so don't add them directly to the query but replace them by ilike (code above borrowed from osv/expression.py)