### PR TITLE
[13.0][FIX] l10n_ch_base_bank

### DIFF
--- a/l10n_ch_base_bank/tests/test_create_invoice.py
+++ b/l10n_ch_base_bank/tests/test_create_invoice.py
@@ -18,11 +18,20 @@ class TestCreateMove(common.SavepointCase):
         # define company bank account
         cls.bank_journal = cls.env["account.journal"].create(
             {
+                "name": "Test Bank Journal",
                 "company_id": cls.company.id,
                 "type": "bank",
                 "code": "BNK42",
                 "bank_id": bank.id,
                 "bank_acc_number": "01-1234-1",
+            }
+        )
+        cls.sale_journal = cls.env["account.journal"].create(
+            {
+                "name": "Test Sale Journal",
+                "company_id": cls.company.id,
+                "type": "sale",
+                "code": "SALE123",
             }
         )
         cls.bank_acc = cls.bank_journal.bank_account_id
@@ -37,7 +46,8 @@ class TestCreateMove(common.SavepointCase):
         #     view='account.view_move_form'
         # )
         inv.partner_id = self.partner
-        inv.journal_id = self.bank_journal
+        inv.journal_id = self.sale_journal
+        inv.invoice_partner_bank_id = self.bank_acc
         return inv
 
     def test_emit_move_with_isr_ref(self):

--- a/l10n_ch_base_bank/tests/test_create_invoice.py
+++ b/l10n_ch_base_bank/tests/test_create_invoice.py
@@ -15,29 +15,25 @@ class TestCreateMove(common.SavepointCase):
         bank = cls.env["res.bank"].create(
             {"name": "BCV", "bic": "BBRUBEBB", "clearing": "234234"}
         )
-        # define company bank account
-        cls.bank_journal = cls.env["account.journal"].create(
+        cls.env["res.partner.bank"].create(
             {
-                "name": "Test Bank Journal",
-                "company_id": cls.company.id,
-                "type": "bank",
-                "code": "BNK42",
+                "partner_id": cls.company.partner_id.id,
                 "bank_id": bank.id,
-                "bank_acc_number": "01-1234-1",
+                "acc_number": "ISR",
+                "l10n_ch_isr_subscription_chf": "01-162-8",
+                "sequence": 1,
             }
         )
-        cls.sale_journal = cls.env["account.journal"].create(
+        cls.journal = cls.env["account.journal"].create(
             {
                 "name": "Test Sale Journal",
                 "company_id": cls.company.id,
                 "type": "sale",
                 "code": "SALE123",
+                "bank_id": bank.id,
+                "bank_acc_number": "01-1234-1",
             }
         )
-        cls.bank_acc = cls.bank_journal.bank_account_id
-        cls.bank_acc.write({"l10n_ch_isr_subscription_chf": "01-162-8", "sequence": 1})
-        fields_list = ["company_id", "user_id", "currency_id", "journal_id"]
-        cls.inv_values = cls.env["account.move"].default_get(fields_list)
 
     def new_form(self):
         inv = Form(self.env["account.move"].with_context(default_type="out_invoice"))
@@ -46,8 +42,7 @@ class TestCreateMove(common.SavepointCase):
         #     view='account.view_move_form'
         # )
         inv.partner_id = self.partner
-        inv.journal_id = self.sale_journal
-        inv.invoice_partner_bank_id = self.bank_acc
+        inv.journal_id = self.journal
         return inv
 
     def test_emit_move_with_isr_ref(self):

--- a/l10n_ch_base_bank/tests/test_search_invoice.py
+++ b/l10n_ch_base_bank/tests/test_search_invoice.py
@@ -25,10 +25,11 @@ class TestSearchmove(common.SavepointCase):
             }
         )
         cls.partner = cls.env["res.partner"].create({"name": "Test"})
-        cls.bank_journal = cls.env["account.journal"].create(
+        cls.journal = cls.env["account.journal"].create(
             {
+                "name": "Test Journal",
                 "company_id": cls.company.id,
-                "type": "bank",
+                "type": "sale",
                 "code": "BNK42",
                 "bank_id": bank.id,
                 "bank_acc_number": "10-8060-7",
@@ -42,7 +43,7 @@ class TestSearchmove(common.SavepointCase):
         #     view='account.view_move_form'
         # )
         inv.partner_id = self.partner
-        inv.journal_id = self.bank_journal
+        inv.journal_id = self.journal
         return inv
 
     def assert_find_ref(self, ref, operator, value):

--- a/l10n_ch_base_bank/tests/test_search_invoice.py
+++ b/l10n_ch_base_bank/tests/test_search_invoice.py
@@ -12,6 +12,7 @@ class TestSearchmove(common.SavepointCase):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.company = cls.env.ref("base.main_company")
+        cls.partner = cls.env.ref("base.res_partner_12")
         bank = cls.env["res.bank"].create(
             {"name": "BCV", "bic": "BBRUBEBB", "clearing": "234234"}
         )
@@ -24,13 +25,12 @@ class TestSearchmove(common.SavepointCase):
                 "sequence": 1,
             }
         )
-        cls.partner = cls.env["res.partner"].create({"name": "Test"})
         cls.journal = cls.env["account.journal"].create(
             {
                 "name": "Test Journal",
                 "company_id": cls.company.id,
                 "type": "sale",
-                "code": "BNK42",
+                "code": "SALE123",
                 "bank_id": bank.id,
                 "bank_acc_number": "10-8060-7",
             }


### PR DESCRIPTION
On an unrelated PR the test for l10n_ch_base_bank were broken.
It seems to be related to this new change introduced by

* https://github.com/odoo/odoo/pull/67599

Which test the valid of the type journal.

So this fixes the test, but I am not sure if they are still meaningfull.