### PR TITLE
[10.0][FIX] l10n_ch_base_bank

### DIFF
--- a/l10n_ch_base_bank/models/invoice.py
+++ b/l10n_ch_base_bank/models/invoice.py
@@ -28,17 +28,17 @@ class AccountInvoice(models.Model):
                 continue
             if value:
                 value = value.replace(' ', '')
-                if not value:
-                    # original value contains only spaces, the query
-                    # would return all rows, so avoid a costly search
-                    # and drop the domain triplet
-                    continue
-                # add wildcards for the like search, except if the operator
-                # is =like of =ilike because they are supposed to be there yet
-                if operator.startswith('='):
-                    operator = operator[1:]
-                else:
-                    value = '%%%s%%' % (value,)
+            if not value:
+                # original value contains only spaces, the query
+                # would return all rows, so avoid a costly search
+                # and drop the domain triplet
+                continue
+            # add wildcards for the like search, except if the operator
+            # is =like of =ilike because they are supposed to be there yet
+            if operator.startswith('='):
+                operator = operator[1:]
+            else:
+                value = '%%%s%%' % (value,)
             query = ("SELECT id FROM account_invoice "
                      "WHERE REPLACE(reference, ' ', '') %s %%s" %
                      (operator,))


### PR DESCRIPTION
At some point, while importing Invoice as PDF with Import Vendor Bill wizard, we have an issue on the search for existing Invoices.
At the moment, if the value is not set, we got:
`=like` operator transforms in Odoo to Postgres query like `SELECT column like 'value'`
this is not what we want. Instead, to avoid missing Invoices, we need this kind of query:
`like` operator transforms in Odoo to Postgres query like `SELECT column like '%svalue%s'`