### PR TITLE
[10.0]  l10n_ch_qr_bill: Fix QR bill reference

### DIFF
--- a/l10n_ch_qr_bill/controllers/main.py
+++ b/l10n_ch_qr_bill/controllers/main.py
@@ -24,9 +24,9 @@ class ReportController(Controller):
         This adds `bar_border` capability.
 
         Samples:
-            <img t-att-src="'/report/qrcode/%s' % o.name"/>
-            <img t-att-src="'/report/qrcode/?value=%s&amp;width=%s&amp;height=%s' %
-                (o.name, 200, 200)"/>
+        <img t-att-src="'/report/qrcode/%s' % o.name"/>
+        <img t-att-src="'/report/qrcode/?value=%s&amp;width=%s&amp;height=%s'
+        % (o.name, 200, 200)"/>
 
         :param bar_border: Size of blank border, use 0 to remove border.
         """

--- a/l10n_ch_qr_bill/models/account_invoice.py
+++ b/l10n_ch_qr_bill/models/account_invoice.py
@@ -269,9 +269,13 @@ class AccountInvoice(models.Model):
             and reference == mod10r(reference[:-1])
         )
 
+
+    def _get_reference_to_check(self):
+        return self.reference
+
     def validate_swiss_code_arguments(self):
         # TODO do checks separately
-        reference_to_check = self.name
+        reference_to_check = self._get_reference_to_check()
 
         def _partner_fields_set(partner):
             return (

--- a/l10n_ch_qr_bill/models/account_invoice.py
+++ b/l10n_ch_qr_bill/models/account_invoice.py
@@ -2,7 +2,6 @@
 # Copyright 2019-2020 Odoo
 # Copyright 2019-2020 Camptocamp SA
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
-
 import re
 
 import werkzeug.urls
@@ -242,7 +241,7 @@ class AccountInvoice(models.Model):
 
         # use quiet to remove blank around the QR
         # and make it easier to place it
-        return '/report/qrcode/?value=%s&width=%s&height=%s&bar_border=0' % (
+        return '/report/qrcode/?value=%s&width=%s&height=%s&bar_border=0&barlevel=M' % (
             werkzeug.urls.url_quote_plus('\n'.join(qr_code_vals)),
             256,
             256,

--- a/l10n_ch_qr_bill/models/account_invoice.py
+++ b/l10n_ch_qr_bill/models/account_invoice.py
@@ -55,7 +55,9 @@ class AccountInvoice(models.Model):
             "to generate QR-bill report."
         ),
     )
-    # This field is used in the "invisible" condition field of the 'Print QRR' button.
+    """ This field is used in the "invisible" condition field
+        of the 'Print QRR' button.
+    """
     l10n_ch_currency_name = fields.Char(
         related='currency_id.name',
         readonly=True,
@@ -157,9 +159,9 @@ class AccountInvoice(models.Model):
                 else free_communication
             )
 
-        # Compute reference type (empty by default, only mandatory for QR-IBAN,
-        # and must then be 27 characters-long, with mod10r check digit as the 27th one,
-        # just like ISR number for invoices)
+        # Compute reference type (empty by default, only mandatory for
+        # QR-IBAN, and must then be 27 characters-long, with mod10r check
+        # digit as the 27th one, just like ISR number for invoices)
         reference_type = 'NON'
         reference = ''
         if is_qrr:
@@ -238,7 +240,8 @@ class AccountInvoice(models.Model):
 
         qr_code_vals = self._prepare_swiss_code_url_vals()
 
-        # use quiet to remove blank around the QR and make it easier to place it
+        # use quiet to remove blank around the QR
+        # and make it easier to place it
         return '/report/qrcode/?value=%s&width=%s&height=%s&bar_border=0' % (
             werkzeug.urls.url_quote_plus('\n'.join(qr_code_vals)),
             256,
@@ -246,9 +249,9 @@ class AccountInvoice(models.Model):
         )
 
     def _get_partner_address_lines(self, partner):
-        """ Returns a tuple of two elements containing the address lines to use
-        for this partner. Line 1 contains the street and number, line 2 contains
-        zip and city. Those two lines are limited to 70 characters
+        """ Returns a tuple of two elements containing the address lines to
+        use for this partner. Line 1 contains the street and number, line 2
+        contains zip and city. Those two lines are limited to 70 characters
         """
         streets = [partner.street, partner.street2]
         line_1 = ' '.join(filter(None, streets))
@@ -258,7 +261,8 @@ class AccountInvoice(models.Model):
     @api.model
     def _is_qrr(self, reference):
         """ Checks whether the given reference is a QR-reference, i.e. it is
-        made of 27 digits, the 27th being a mod10r check on the 26 previous ones.
+        made of 27 digits, the 27th being a mod10r check on the 26 previous
+        ones.
         """
         if not reference:
             return False
@@ -268,7 +272,6 @@ class AccountInvoice(models.Model):
             and re.match(r'\d+$', reference)
             and reference == mod10r(reference[:-1])
         )
-
 
     def _get_reference_to_check(self):
         return self.reference

--- a/l10n_ch_qr_bill/models/res_bank.py
+++ b/l10n_ch_qr_bill/models/res_bank.py
@@ -36,7 +36,7 @@ class ResPartnerBank(models.Model):
             return False
         iid_start_index = 4
         iid_end_index = 8
-        iid = iban[iid_start_index : iid_end_index + 1]
+        iid = iban[iid_start_index:iid_end_index + 1]
         # Those iid between 30000 and 31999 are reserved for QR-IBANs only
         return (re.match(r'\d+', iid)
                 and 30000 <= int(iid) <= 31999)
@@ -73,10 +73,10 @@ class ResPartnerBank(models.Model):
         return super(ResPartnerBank, self).write(vals)
 
     def _is_qr_iban(self):
-        """ Tells whether or not this bank account has a QR-IBAN account number.
-        QR-IBANs are specific identifiers used in Switzerland as references in
-        QR-codes. They are formed like regular IBANs, but are actually something
-        different.
+        """ Tells whether or not this bank account has a QR-IBAN account
+        number. QR-IBANs are specific identifiers used in Switzerland as
+        references in QR-codes. They are formed like regular IBANs, but
+        are actually something different.
 
         """
         return (

--- a/l10n_ch_qr_bill/tests/test_swissqr.py
+++ b/l10n_ch_qr_bill/tests/test_swissqr.py
@@ -143,9 +143,9 @@ class TestSwissQR(AccountingTestCase):
         self.assertEqual(url, expected_url)
 
     def test_swissQR_missing_bank(self):
-        # Let us test the generation of a SwissQR for an invoice, first by showing an
-        # QR is included in the invoice is only generated when Odoo has all the data
-        # it needs.
+        # Let us test the generation of a SwissQR for an invoice,
+        # first by showing an QR is included in the invoice is only
+        # generated when Odoo has all the data it needs.
         self.invoice1.action_invoice_open()
         self.swissqr_not_generated(self.invoice1)
 

--- a/l10n_ch_qr_bill_transaction_id/models/account_invoice.py
+++ b/l10n_ch_qr_bill_transaction_id/models/account_invoice.py
@@ -55,3 +55,7 @@ class AccountInvoice(models.Model):
         res = super(AccountInvoice, self).action_move_create()
         self._post_propagate_qrr()
         return res
+
+
+    def _get_reference_to_check(self):
+        return self.transaction_id


### PR DESCRIPTION
QR-Bill generation raise the error
"With a QR-IBAN a valid QRR must be used."

The reason is that `l10n_ch_qr_bill` expects a QRR inside self.name of the invoice.
However, we have a second module `l10n_ch_qr_bill_transaction_id` that should replace this behavior.