### PR TITLE
[10.0][FIX] l10n_ch_qr_bill: use reference for check

### DIFF
--- a/l10n_ch_qr_bill/models/account_invoice.py
+++ b/l10n_ch_qr_bill/models/account_invoice.py
@@ -323,7 +323,7 @@ class AccountInvoice(models.Model):
         """Check if this invoice has a valid QRR reference (for Switzerland)
 
         """
-        return self._is_qrr(self.name)
+        return self._is_qrr(self.reference)
 
     def _validate_qrr(self):
         partner_bank = self.partner_bank_id


### PR DESCRIPTION
name for the invoice is given from sequence it is not valid to use it for checking qrr