### PR TITLE
FIX [12.0] Update view according to l10n_ch

### DIFF
--- a/l10n_ch_payment_slip/views/account_invoice.xml
+++ b/l10n_ch_payment_slip/views/account_invoice.xml
@@ -14,11 +14,15 @@
       <field name="type">form</field>
       <field name="inherit_id" ref="l10n_ch.isr_invoice_form"/>
       <field name="arch" type="xml">
-        <xpath expr="//button[@name='isr_print']" position="attributes">
+        <button id="l10n_ch_btn_isr_print_highlight" position="attributes">
           <attribute name="invisible">1</attribute>
           <attribute name="attrs"/>
-        </xpath>
-        <xpath expr="//button[@name='action_invoice_sent']" position="after">
+        </button>
+        <button id="btn_isr_print_normal" position="attributes">
+          <attribute name="invisible">1</attribute>
+          <attribute name="attrs"/>
+        </button>
+        <xpath expr="//button[@id='account_invoice_payment_btn']" position="before">
           <button type="object"
                   string="Print CH ISR"
                   name="print_isr"


### PR DESCRIPTION
hide the two default buttons with name="isr_print"
be sure that pyaments slip buttons are inserted after Send & Print buttons as there are 2 buttons with name="action_invoice_sent"