### PR TITLE
ebill_paynet: Use picking name as ref in REFERENCE-DATE

### DIFF
--- a/ebill_paynet/messages/invoice-2003A.xml
+++ b/ebill_paynet/messages/invoice-2003A.xml
@@ -44,11 +44,11 @@
         </ORDER>
         {%- endif %}
         {% endfor %}
-        {% for picking in invoice_lines.sale_line_ids.move_ids.mapped('picking_id') %}
-        {%- if picking.carrier_tracking_ref and picking.state != 'cancel' %}
+        {% for picking in invoice_lines.sale_line_ids.move_ids.mapped('picking_id')[:9] %}
+        {%- if picking.state != 'cancel' %}
         <DELIVERY-NOTE>
           <REFERENCE-DATE>
-            <Reference-No>{{ picking.carrier_tracking_ref|truncate(35, True, "") }}</Reference-No>
+            <Reference-No>{{ picking.name }}</Reference-No>
             {%- if picking.date_done %}
             <Date Format="CCYYMMDD">{{ format_date(picking.date_done) }}</Date>
             {%- endif %}

--- a/ebill_paynet/tests/common.py
+++ b/ebill_paynet/tests/common.py
@@ -159,7 +159,7 @@ class CommonCase(SavepointCase, XmlTestMixin):
         cls.sale.date_order = "2019-06-01"
         # Set a delivery tracking number
         cls.pickings = cls.sale.order_line.move_ids.mapped("picking_id")
-        cls.pickings[0].carrier_tracking_ref = "track_me_if_you_can"
+        cls.pickings[0].name = "Picking Name"
         # Generate the invoice from the sale order
         cls.invoice = cls.sale._create_invoices()
         # And add some more lines on the invoice

--- a/ebill_paynet/tests/examples/invoice_isr_b2b.xml
+++ b/ebill_paynet/tests/examples/invoice_isr_b2b.xml
@@ -42,7 +42,7 @@
         </ORDER>
         <DELIVERY-NOTE>
           <REFERENCE-DATE>
-            <Reference-No>track_me_if_you_can</Reference-No>
+            <Reference-No>Picking Name</Reference-No>
             <!-- <Date Format="CCYYMMDD">20190620</Date> -->
           </REFERENCE-DATE>
         </DELIVERY-NOTE>

--- a/ebill_paynet/tests/examples/invoice_qr_b2b.xml
+++ b/ebill_paynet/tests/examples/invoice_qr_b2b.xml
@@ -42,7 +42,7 @@
         </ORDER>
         <DELIVERY-NOTE>
           <REFERENCE-DATE>
-            <Reference-No>track_me_if_you_can</Reference-No>
+            <Reference-No>Picking Name</Reference-No>
             <!-- <Date Format="CCYYMMDD">20190620</Date> -->
           </REFERENCE-DATE>
         </DELIVERY-NOTE>

--- a/ebill_paynet_customer_free_ref/tests/examples/invoice_b2b.xml
+++ b/ebill_paynet_customer_free_ref/tests/examples/invoice_b2b.xml
@@ -42,7 +42,7 @@
         </ORDER>
         <DELIVERY-NOTE>
           <REFERENCE-DATE>
-            <Reference-No>track_me_if_you_can</Reference-No>
+            <Reference-No>Picking Name</Reference-No>
             <!-- <Date Format="CCYYMMDD">20190620</Date> -->
           </REFERENCE-DATE>
         </DELIVERY-NOTE>


### PR DESCRIPTION
Customers complained that the reference should be the picking name instead of the tracking reference, in the message.