### PR TITLE
[10.0][FIX] set reference_type to QRR

### DIFF
--- a/l10n_ch_qr_bill/models/account_invoice.py
+++ b/l10n_ch_qr_bill/models/account_invoice.py
@@ -80,12 +80,11 @@ class AccountInvoice(models.Model):
         self.ensure_one()
         return ''
 
-    @api.onchange('reference')
+    @api.onchange('reference', 'partner_bank_id')
     def onchange_reference_name(self):
         # onchange_reference method defined in l10n_ch_base_bank
         # to not bring dependency on this addon we defined method which will
-        # disable behavior of onchange_reference
-        if self.has_qrr():
+        if self.has_qrr() and self.partner_bank_id._is_qr_iban():
             self.reference_type = 'QRR'
             return
 

--- a/l10n_ch_qr_bill/models/account_invoice.py
+++ b/l10n_ch_qr_bill/models/account_invoice.py
@@ -80,6 +80,15 @@ class AccountInvoice(models.Model):
         self.ensure_one()
         return ''
 
+    @api.onchange('reference')
+    def onchange_reference_name(self):
+        # onchange_reference method defined in l10n_ch_base_bank
+        # to not bring dependency on this addon we defined method which will
+        # disable behavior of onchange_reference
+        if self.has_qrr():
+            self.reference_type = 'QRR'
+            return
+
     @api.depends('number', 'name')
     def _compute_l10n_ch_qrr(self):
         r""" Compute a QRR reference


### PR DESCRIPTION
set reference to qrr as otherwise, it will propagate wrong type to order payments 