### PR TITLE
l10n_ch_base_bank remove isr check

### DIFF
--- a/l10n_ch_base_bank/models/invoice.py
+++ b/l10n_ch_base_bank/models/invoice.py
@@ -1,6 +1,6 @@
 # Copyright 2012-2019 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import _, api, exceptions, models
+from odoo import models
 
 
 class AccountMove(models.Model):
@@ -67,42 +67,6 @@ class AccountMove(models.Model):
             count=count,
             access_rights_uid=access_rights_uid,
         )
-
-    @api.constrains("ref", "payment_reference")
-    def _check_bank_type_for_type_isr(self):
-        """Compatibility with module `account_payment_partner`"""
-        for move in self:
-            if move.move_type == "out_invoice" and move._has_isr_ref():
-                if hasattr(super(), "partner_banks_to_show"):
-                    bank_acc = move.partner_banks_to_show()
-                else:
-                    bank_acc = move.partner_bank_id
-                if not bank_acc:
-                    raise exceptions.ValidationError(
-                        _(
-                            "Bank account shouldn't be empty, for ISR ref"
-                            " type, you can set it manually or set appropriate"
-                            " payment mode."
-                        )
-                    )
-                if (
-                    bank_acc.acc_type != "qr-iban"
-                    and (
-                        move.currency_id.name == "CHF"
-                        and not bank_acc.l10n_ch_isr_subscription_chf
-                    )
-                    or (
-                        move.currency_id.name == "EUR"
-                        and not bank_acc.l10n_ch_isr_subscription_eur
-                    )
-                ):
-                    raise exceptions.ValidationError(
-                        _(
-                            "Bank account must contain a subscription number for"
-                            " ISR ref type."
-                        )
-                    )
-        return True
 
     def partner_banks_to_show(self):
         """


### PR DESCRIPTION
ISR is not used anymore in Switzerland => We drop ` _check_bank_type_for_type_isr`