### PR TITLE
[14.0][FIX] l10n_ch_delivery_carrier_label_quickpac: missing condition for …

### DIFF
--- a/l10n_ch_delivery_carrier_label_quickpac/models/stock.py
+++ b/l10n_ch_delivery_carrier_label_quickpac/models/stock.py
@@ -12,9 +12,10 @@ class StockPicking(models.Model):
 
     def onchange_carrier_id(self):
         result = super().onchange_carrier_id()
-        web_service = QuickpacWebService(self.env.user.company_id)
-        zipcode = self.partner_id.zip
-        web_service.is_deliverable_zipcode(zipcode)
+        if self.carrier_id.delivery_type == "quickpac":
+            web_service = QuickpacWebService(self.env.user.company_id)
+            zipcode = self.partner_id.zip
+            web_service.is_deliverable_zipcode(zipcode)
         return result
 
     def _generate_quickpac_label(self, webservice_class=None, package_ids=None):


### PR DESCRIPTION
Missing condition for quickpac when changing carrier on pickings

This PR https://github.com/OCA/l10n-switzerland/pull/637 introduced a bug while using onchange_carrier_id with different carrier than Quickpac.