### PR TITLE
[14.0][FIX] Disable ebill_paynet unit test

### DIFF
--- a/ebill_paynet/tests/__init__.py
+++ b/ebill_paynet/tests/__init__.py
@@ -1,5 +1,6 @@
-from . import test_ebill_paynet
-
+# Disabling all tests because this module should not be used anymore
+# Service from SIX has been shut down
+# from . import test_ebill_paynet
 # Test for the B2C implemenation wich is not done, yet
 # from . import test_invoice_message
-from . import test_invoice_message_b2b
+# from . import test_invoice_message_b2b

--- a/ebill_paynet_customer_free_ref/tests/__init__.py
+++ b/ebill_paynet_customer_free_ref/tests/__init__.py
@@ -1,1 +1,3 @@
-from . import test_ebill_paynet_customer_free_ref
+# Disabling all tests because this module should not be used anymore
+# Service from SIX has been shut down
+# from . import test_ebill_paynet_customer_free_ref


### PR DESCRIPTION
This module should not be used anymore because the service has been shut down.
Use ebill_postfinance instead (still in PR form)