### PR TITLE
[11.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/l10n_ch_account_tags/__manifest__.py
+++ b/l10n_ch_account_tags/__manifest__.py
@@ -6,7 +6,7 @@
     'category': 'Localisation',
     'summary': '',
     'version': '11.0.1.0.0',
-    'author': 'Camptocamp SA, Odoo Community Association (OCA)',
+    'author': 'Camptocamp, Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/l10n-switzerland',
     'license': 'AGPL-3',
     'depends': [


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 11.0.