### PR TITLE
[14.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/ebill_paynet/__manifest__.py
+++ b/ebill_paynet/__manifest__.py
@@ -7,7 +7,7 @@
         Paynet platform bridge implementation""",
     "version": "14.0.1.1.4",
     "license": "AGPL-3",
-    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
     "maintainers": ["TDu"],
     "website": "https://github.com/OCA/l10n-switzerland",
     "depends": [

--- a/ebill_paynet_customer_free_ref/__manifest__.py
+++ b/ebill_paynet_customer_free_ref/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": "Glue module: ebill_paynet and sale_order_customer_free_ref",
     "version": "14.0.1.0.2",
     "license": "AGPL-3",
-    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-switzerland",
     "depends": ["ebill_paynet", "sale_order_customer_free_ref"],
     "auto_install": True,

--- a/l10n_ch_account_tags/__manifest__.py
+++ b/l10n_ch_account_tags/__manifest__.py
@@ -6,7 +6,7 @@
     "category": "Localisation",
     "summary": "",
     "version": "14.0.1.0.0",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-switzerland",
     "license": "AGPL-3",
     "depends": ["l10n_ch"],


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.