### PR TITLE
[14.0][FEAT]: Improve l10n_ch_invoice_reports

### DIFF
--- a/l10n_ch_invoice_reports/README.rst
+++ b/l10n_ch_invoice_reports/README.rst
@@ -47,6 +47,7 @@ Usage
 =====
 
 Print report using one of 3 additional print actions in Accounting
+Define which reports will be printed using the new settings added into accounting res settings
 
 Bug Tracker
 ===========
@@ -72,6 +73,7 @@ Contributors
 * Anna Janiszewska <anna.janiszewska@camptocamp.com>
 * `Trobz <https://trobz.com>`_:
     * Son Ho <sonhd@trobz.com>
+* Victor Vermot <victor.vermot@camptocamp.com>
 
 Other credits
 ~~~~~~~~~~~~~

--- a/l10n_ch_invoice_reports/__manifest__.py
+++ b/l10n_ch_invoice_reports/__manifest__.py
@@ -3,13 +3,17 @@
 {
     "name": "Switzerland - Invoice Reports with payment option",
     "summary": "Extend invoice to add ISR/QR payment slip",
-    "version": "14.0.1.3.0",
+    "version": "14.0.1.4.0",
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "category": "Localization",
     "website": "https://github.com/OCA/l10n-switzerland",
     "license": "AGPL-3",
     "depends": ["account", "l10n_ch", "web"],
-    "data": ["data/reports.xml", "data/mail_template.xml"],
+    "data": [
+        "data/reports.xml",
+        "data/mail_template.xml",
+        "views/res_config_settings.xml",
+    ],
     "auto_install": False,
     "installable": True,
 }

--- a/l10n_ch_invoice_reports/i18n/l10n_ch_invoice_reports.pot
+++ b/l10n_ch_invoice_reports/i18n/l10n_ch_invoice_reports.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0\n"
+"Project-Id-Version: Odoo Server 14.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-11 11:42+0000\n"
+"PO-Revision-Date: 2024-09-11 11:42+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,6 +18,18 @@ msgstr ""
 #. module: l10n_ch_invoice_reports
 #: model:ir.actions.report,print_report_name:l10n_ch_invoice_reports.account_move_payment_report
 msgid "('invoice-payment-slip_'+object.name)"
+msgstr ""
+
+#. module: l10n_ch_invoice_reports
+#: model_terms:ir.ui.view,arch_db:l10n_ch_invoice_reports.res_config_settings_view_form
+msgid ""
+"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
+"specific.\"/>"
+msgstr ""
+
+#. module: l10n_ch_invoice_reports
+#: model_terms:ir.ui.view,arch_db:l10n_ch_invoice_reports.res_config_settings_view_form
+msgid "<span class=\"o_form_label\">Invoice report options</span>"
 msgstr ""
 
 #. module: l10n_ch_invoice_reports
@@ -50,6 +64,12 @@ msgid "ID"
 msgstr ""
 
 #. module: l10n_ch_invoice_reports
+#: model:ir.model.fields,field_description:l10n_ch_invoice_reports.field_res_company__invoice_report_id
+#: model:ir.model.fields,field_description:l10n_ch_invoice_reports.field_res_config_settings__invoice_report_id
+msgid "Invoice Report"
+msgstr ""
+
+#. module: l10n_ch_invoice_reports
 #: model:ir.actions.report,name:l10n_ch_invoice_reports.account_move_payment_report
 msgid "Invoice with payment slip(s)"
 msgstr ""
@@ -69,6 +89,27 @@ msgid "Print invoice with QR bill"
 msgstr ""
 
 #. module: l10n_ch_invoice_reports
+#: model:ir.model.fields,field_description:l10n_ch_invoice_reports.field_res_company__qr_report_id
+#: model:ir.model.fields,field_description:l10n_ch_invoice_reports.field_res_config_settings__qr_report_id
+msgid "QR Report"
+msgstr ""
+
+#. module: l10n_ch_invoice_reports
+#: model_terms:ir.ui.view,arch_db:l10n_ch_invoice_reports.res_config_settings_view_form
+msgid "QR invoice printed"
+msgstr ""
+
+#. module: l10n_ch_invoice_reports
 #: model:ir.model,name:l10n_ch_invoice_reports.model_ir_actions_report
 msgid "Report Action"
+msgstr ""
+
+#. module: l10n_ch_invoice_reports
+#: model_terms:ir.ui.view,arch_db:l10n_ch_invoice_reports.res_config_settings_view_form
+msgid "Report invoice printed"
+msgstr ""
+
+#. module: l10n_ch_invoice_reports
+#: model_terms:ir.ui.view,arch_db:l10n_ch_invoice_reports.res_config_settings_view_form
+msgid "This option will be applied on invoice report"
 msgstr ""

--- a/l10n_ch_invoice_reports/models/report.py
+++ b/l10n_ch_invoice_reports/models/report.py
@@ -42,9 +42,18 @@ class IrActionsReport(models.Model):
         if self.report_name not in reports or not res_ids:
             return super()._render_qweb_pdf(res_ids, data)
 
-        inv_report = self._get_report_from_name("account.report_invoice")
-        qr_report = self._get_report_from_name("l10n_ch.qr_report_main")
-
+        inv_report_id = self.env["ir.config_parameter"].sudo().get_param(
+            "invoice_report_id"
+        ) and int(self.env["ir.config_parameter"].sudo().get_param("invoice_report_id"))
+        inv_report = self.env["ir.actions.report"].browse(
+            inv_report_id
+        ) or self._get_report_from_name("account.report_invoice")
+        qr_report_id = self.env["ir.config_parameter"].sudo().get_param(
+            "qr_report_id"
+        ) and int(self.env["ir.config_parameter"].sudo().get_param("qr_report_id"))
+        qr_report = self.env["ir.actions.report"].browse(
+            qr_report_id
+        ) or self._get_report_from_name("l10n_ch.qr_report_main")
         io_list = []
         for inv in self.env["account.move"].browse(res_ids):
             invoice_pdf, _ = inv_report._render_qweb_pdf(inv.id, data)

--- a/l10n_ch_invoice_reports/models/res_company.py
+++ b/l10n_ch_invoice_reports/models/res_company.py
@@ -8,3 +8,5 @@ class ResCompany(models.Model):
         string="Print invoice with QR bill",
         default=True,
     )
+    invoice_report_id = fields.Many2one("ir.actions.report", string="Invoice Report")
+    qr_report_id = fields.Many2one("ir.actions.report", string="QR Report")

--- a/l10n_ch_invoice_reports/models/res_config_settings.py
+++ b/l10n_ch_invoice_reports/models/res_config_settings.py
@@ -9,3 +9,15 @@ class ResConfigSettings(models.TransientModel):
         string="Print invoice with QR bill",
         readonly=False,
     )
+    invoice_report_id = fields.Many2one(
+        related="company_id.invoice_report_id",
+        string="Invoice Report",
+        readonly=False,
+        config_parameter="invoice_report_id",
+    )
+    qr_report_id = fields.Many2one(
+        related="company_id.qr_report_id",
+        string="QR Report",
+        readonly=False,
+        config_parameter="qr_report_id",
+    )

--- a/l10n_ch_invoice_reports/readme/CONTRIBUTORS.rst
+++ b/l10n_ch_invoice_reports/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Anna Janiszewska <anna.janiszewska@camptocamp.com>
 * `Trobz <https://trobz.com>`_:
     * Son Ho <sonhd@trobz.com>
+* Victor Vermot <victor.vermot@camptocamp.com>

--- a/l10n_ch_invoice_reports/readme/USAGE.rst
+++ b/l10n_ch_invoice_reports/readme/USAGE.rst
@@ -1,1 +1,2 @@
 Print report using one of 3 additional print actions in Accounting
+Define which reports will be printed using the new settings added into accounting res settings

--- a/l10n_ch_invoice_reports/static/description/index.html
+++ b/l10n_ch_invoice_reports/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -394,7 +394,8 @@ detail in the same pdf file.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
-<p>Print report using one of 3 additional print actions in Accounting</p>
+<p>Print report using one of 3 additional print actions in Accounting
+Define which reports will be printed using the new settings added into accounting res settings</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
@@ -424,6 +425,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </dd>
 </dl>
 </li>
+<li>Victor Vermot &lt;<a class="reference external" href="mailto:victor.vermot&#64;camptocamp.com">victor.vermot&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">
@@ -433,7 +435,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/l10n_ch_invoice_reports/views/res_config_settings.xml
+++ b/l10n_ch_invoice_reports/views/res_config_settings.xml
@@ -15,17 +15,34 @@
                         </div>
                         <div class="mt16">
                             <div class="content-group" id="invoice_report_options">
-                                <div class="row">
-                                    <field
-                                        name="print_qr_invoice"
-                                        class="col-lg-1 ml16"
-                                    />
-                                    <label for="print_qr_invoice" />
+                                <field name="print_qr_invoice" class="mb16" />
+                                <label for="print_qr_invoice" />
+                                <span
+                                    class="fa fa-lg fa-building-o"
+                                    title="Values set here are company-specific."
+                                />
+                                <div>
+                                    <label for="invoice_report_id" />
                                     <span
                                         class="fa fa-lg fa-building-o"
                                         title="Values set here are company-specific."
                                     />
                                 </div>
+                                <div class="text-muted">
+                                    Report invoice printed
+                                </div>
+                                <field name="invoice_report_id" class="mb16" />
+                                <div>
+                                    <label for="qr_report_id" />
+                                    <span
+                                        class="fa fa-lg fa-building-o"
+                                        title="Values set here are company-specific."
+                                    />
+                                </div>
+                                    <div class="text-muted">
+                                        QR invoice printed
+                                    </div>
+                                <field name="qr_report_id" class="mb16" />
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
We want the customer to be able to chose which reports will be printed when choosing to print Invoice with payment slip(s)

I added some settings to be able to chose which reports are printed.
![fmel_722_1](https://github.com/user-attachments/assets/73d9b979-cfc1-4219-bc0e-5c37f235a42a)

### Result 
- You can now print reports that show payment with the option "print invoice with payment slip(s)"
![fmel_722_3](https://github.com/user-attachments/assets/268d46fd-5595-402e-b4e6-70dd51266158)

