### PR TITLE
[17.0][FIX] l10n_ch_qr_no_amount: Do not encode amount in QR code

### DIFF
--- a/l10n_ch_qr_no_amount/report/swissqr_no_amount_report.py
+++ b/l10n_ch_qr_no_amount/report/swissqr_no_amount_report.py
@@ -1,7 +1,12 @@
-from odoo import models
+from odoo import api, models
 
 
 class ReportSwissNoAmountQR(models.AbstractModel):
     _name = "report.l10n_ch_qr_no_amount.qr_no_amount_report_main"
     _inherit = "report.l10n_ch.qr_report_main"
     _description = "QR-No-Amount-bill"
+
+    @api.model
+    def _get_report_values(self, docids, data=None):
+        self = self.with_context(_no_amount_qr_code=True)
+        return super()._get_report_values(docids, data)


### PR DESCRIPTION
As the context key was not set, the QR code did still include amount information although it is not printed on the QR bill.

ref: BSSMS-453