### PR TITLE
[16.0][IMP] ebill_postfinance: allow report name configuration

### DIFF
--- a/ebill_postfinance/models/account_move.py
+++ b/ebill_postfinance/models/account_move.py
@@ -42,30 +42,36 @@ class AccountMove(models.Model):
         self.invoice_exported = True
         return "Postfinance invoice generated and in state {}".format(message.state)
 
+    def _get_ebill_postfinance_pdf_report(self, payment_type):
+        """Get the report name(s) to be used to generate the pdf send with the eBill."""
+        report_names = ["account.report_invoice"]
+        if self.move_type == "out_invoice":
+            # Should it not depends on the invoice being sent, instead of a
+            # configuration on the contract ?
+            if payment_type == "qr":
+                report_names.append("l10n_ch.qr_report_main")
+        return report_names
+
     def create_postfinance_ebill(self):
         """Generate the message record for an invoice."""
         self.ensure_one()
         contract = self.partner_id.get_active_contract(self.transmit_method_id)
         if not contract:
             return
+        payment_type = ""
+        if self.move_type == "out_invoice":
+            payment_type = "iban"
+        elif self.move_type == "out_refund":
+            payment_type = "credit"
         # Generate PDf to be send
         pdf_data = []
         # When test are run, pdf are not generated, so use an empty pdf
         pdf = b""
-        report_names = ["account.report_invoice"]
-        payment_type = ""
-        if self.move_type == "out_invoice":
-            payment_type = "iban"
-            if contract.payment_type == "qr":
-                report_names.append("l10n_ch.qr_report_main")
-        elif self.move_type == "out_refund":
-            payment_type = "credit"
+        report_names = self._get_ebill_postfinance_pdf_report(payment_type)
         for report_name in report_names:
-            # r = self.env["ir.actions.report"]._get_report_from_name(report_name)
             pdf_content, _ = self.env["ir.actions.report"]._render(
                 report_name, [self.id]
             )
-            # pdf_content, _ = r._render([self.id])
             pdf_data.append(pdf_content)
         if not odoo.tools.config["test_enable"]:
             if len(pdf_data) > 1:


### PR DESCRIPTION
This change allows to select a specific report name for the pdf being included in the eBill sent.
No parameters in the UI, yet. Because not sure how this should be handled.