### PR TITLE
[18.0] ebill_postfinance: integrate financial discount

### DIFF
--- a/ebill_postfinance/messages/invoice-yellowbill.jinja
+++ b/ebill_postfinance/messages/invoice-yellowbill.jinja
@@ -210,10 +210,16 @@
                     <TotalTax>{{ invoice.amount_tax|round(6) }}</TotalTax>
                 </Tax>
                 {% endif -%}
-                {# <Discount> #}
-                {#     <Days></Days> #}
-                {#     <Rate></Rate> #}
-                {# </Discount> #}
+                {% for discount in discounts %}
+                <Discount>
+                  {% if discount.days %}
+                  <Days>{{ discount.days }}</Days>
+                  {% else %}
+                  <DiscountDate>{{ discount.date }}</DiscountDate>
+                  {% endif -%}
+                  <Rate>{{ discount.percentage }}</Rate>
+                </Discount>
+                {% endfor -%}
                 <TotalAmountExclusiveTax>{{ invoice.amount_untaxed * amount_sign }}</TotalAmountExclusiveTax>
                 <TotalAmountInclusiveTax>{{ invoice.amount_total * amount_sign }}</TotalAmountInclusiveTax>
                 {# <TotalAmountPaid></TotalAmountPaid> #}

--- a/ebill_postfinance/models/ebill_postfinance_invoice_message.py
+++ b/ebill_postfinance/models/ebill_postfinance_invoice_message.py
@@ -299,6 +299,14 @@ class EbillPostfinanceInvoiceMessage(models.Model):
             self.invoice_id.invoice_date_due or self.invoice_id.invoice_date
         )
         params["date_due"] = date_due
+        if self.invoice_id.invoice_payment_term_id.early_discount:
+            terms = self.invoice_id.invoice_payment_term_id
+            params["discounts"].append(
+                {
+                    "percentage": terms.discount_percentage,
+                    "days": terms.discount_days,
+                }
+            )
         return params
 
     def _get_jinja_env(self, template_dir):

--- a/ebill_postfinance/models/ebill_postfinance_invoice_message.py
+++ b/ebill_postfinance/models/ebill_postfinance_invoice_message.py
@@ -224,7 +224,7 @@ class EbillPostfinanceInvoiceMessage(models.Model):
             "format_date": self.format_date,
             "ebill_account_number": self.ebill_account_number,
             "discount_template": "",
-            "discount": {},
+            "discounts": [],
         }
         amount_by_group = []
         # Get the percentage of the tax from the name of the group
@@ -277,7 +277,7 @@ class EbillPostfinanceInvoiceMessage(models.Model):
             "format_date": self.format_date_yb,
             "ebill_account_number": self.ebill_account_number,
             "discount_template": "",
-            "discount": {},
+            "discounts": [],
             "invoice_line_stock_template": "",
         }
         amount_by_group = []

--- a/ebill_postfinance/tests/common.py
+++ b/ebill_postfinance/tests/common.py
@@ -216,4 +216,5 @@ recorder = get_recorder()
 
 
 def clean_xml(txt):
-    return etree.canonicalize(txt.decode(), strip_text=True).encode()
+    clean = etree.canonicalize(txt.decode(), strip_text=True).encode()
+    return etree.tostring(etree.fromstring(clean), pretty_print=True)

--- a/ebill_postfinance/tests/samples/invoice_qr_yb_discount.xml
+++ b/ebill_postfinance/tests/samples/invoice_qr_yb_discount.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Envelope
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    type="string"
+>
+    <Header>
+        <From>Camptocamp SA</From>
+        <To>IPECeBILLServer</To>
+        <UseCase>CreateybInvoice</UseCase>
+        <SessionID>1</SessionID>
+        <Version>2.0</Version>
+        <Status>0</Status>
+        <SoftwareName>Odoo</SoftwareName>
+        <SoftwareVersion>14.0</SoftwareVersion>
+    </Header>
+    <Body>
+        <DeliveryInfo>
+            <BillerID>41101000001021209</BillerID>
+            <eBillAccountID>41010198248040391</eBillAccountID>
+            <DeliveryDate>2019-06-21</DeliveryDate>
+            <TransactionID>$TRANSACTION_ID</TransactionID>
+            <BillDetailsType>PDFAppendix</BillDetailsType>
+            <URLBillDetails />
+        </DeliveryInfo>
+        <Bill>
+            <Header>
+                <DocumentType>BILL</DocumentType>
+                <DocumentID>INV_TEST_01</DocumentID>
+                <DocumentDate>2019-06-21</DocumentDate>
+                <SenderParty>
+                    <TaxLiability>VAT</TaxLiability>
+                    <PartyType>
+                        <Address>
+                            <CompanyName>Camptocamp SA</CompanyName>
+                            <Address1>StreetOne</Address1>
+                            <ZIP>1015</ZIP>
+                            <City>Lausanne</City>
+                            <Country>CH</Country>
+                            <Email>info@camptocamp.com</Email>
+                        </Address>
+                        <TaxID>CHE012345678</TaxID>
+                    </PartyType>
+                </SenderParty>
+                <ReceiverParty>
+                    <PartyType>
+                        <CustomerID>$CUSTOMER_ID</CustomerID>
+                        <Address>
+                            <CompanyName>Test RAD Customer XML</CompanyName>
+                            <Address1>Teststrasse 100</Address1>
+                            <Address2
+                            >This is a very long street name that should be sna</Address2>
+                            <ZIP>1700</ZIP>
+                            <City>Fribourg</City>
+                            <Country>CH</Country>
+                        </Address>
+                        <!-- <TaxID>CHE333222111</TaxID> -->
+                    </PartyType>
+                </ReceiverParty>
+                <DeliveryPlace>
+                    <Address>
+                        <CompanyName>Test RAD Customer XML</CompanyName>
+                        <ZIP>1700</ZIP>
+                        <City>Fribourg</City>
+                        <Country>CH</Country>
+                        <!-- <Contact1>0000000001</Contact1> -->
+                    </Address>
+                </DeliveryPlace>
+                <AchievementDate>
+                    <StartDateAchievement>2019-06-21</StartDateAchievement>
+                    <EndDateAchievement>2019-06-21</EndDateAchievement>
+                </AchievementDate>
+                <Currency>CHF</Currency>
+                <AccountAssignment>
+                    <OrderReference>
+                        <ReferencePosition>1</ReferencePosition>
+                        <ReferenceType>OrderReference</ReferenceType>
+                        <ReferenceValue>CustomerRef</ReferenceValue>
+                    </OrderReference>
+                    <OrderDate>2019-06-01</OrderDate>
+                </AccountAssignment>
+                <Language>en</Language>
+                <PaymentInformation>
+                    <PaymentDueDate>2019-08-20</PaymentDueDate>
+                    <PaymentType>IBAN</PaymentType>
+                    <fixAmount>Yes</fixAmount>
+                    <IBAN>
+                        <BIC>777</BIC>
+                        <BankName>Reserve</BankName>
+                        <IBAN>CH2130808001234567827</IBAN>
+                        <CreditorReference
+                        >210000000003139471430009017</CreditorReference>
+                    </IBAN>
+                </PaymentInformation>
+                <!-- <FreeText>Dies ist eine Musterrechnung mit QR-IBAN Angaben</FreeText> -->
+            </Header>
+            <LineItems>
+                <LineItem>
+                    <LineItemType>NORMAL</LineItemType>
+                    <LineItemID>1</LineItemID>
+                    <ProductDescription>Product Q &amp; A</ProductDescription>
+                    <ProductID>370003021</ProductID>
+                    <Quantity>4.0</Quantity>
+                    <QuantityDescription>Units</QuantityDescription>
+                    <PriceUnit>1</PriceUnit>
+                    <Tax>
+                        <TaxDetail>
+                            <Rate>7.7</Rate>
+                            <Amount>37.88</Amount>
+                            <BaseAmountExclusiveTax>492.0</BaseAmountExclusiveTax>
+                            <BaseAmountInclusiveTax>529.88</BaseAmountInclusiveTax>
+                        </TaxDetail>
+                        <TotalTax>37.88</TotalTax>
+                    </Tax>
+                    <AmountInclusiveTax>529.88</AmountInclusiveTax>
+                    <AmountExclusiveTax>492.0</AmountExclusiveTax>
+                    <FixedReference>
+                        <ReferencePosition>2</ReferencePosition>
+                        <ReferenceType>OrderNumberBySupplier</ReferenceType>
+                        <ReferenceValue>Order123</ReferenceValue>
+                    </FixedReference>
+                    <FixedReference>
+                        <ReferencePosition>3</ReferencePosition>
+                        <ReferenceType>OrderNumberByBuyer</ReferenceType>
+                        <ReferenceValue>CustomerRef</ReferenceValue>
+                    </FixedReference>
+                </LineItem>
+                <LineItem>
+                    <LineItemType>NORMAL</LineItemType>
+                    <LineItemID>2</LineItemID>
+                    <ProductDescription
+                    >Product With a Very Long Name That Need To Be Truncated</ProductDescription>
+                    <ProductID>370003022</ProductID>
+                    <Quantity>1.0</Quantity>
+                    <QuantityDescription>Units</QuantityDescription>
+                    <PriceUnit>1</PriceUnit>
+                    <Tax>
+                        <TaxDetail>
+                            <Rate>7.7</Rate>
+                            <Amount>0.0</Amount>
+                            <BaseAmountExclusiveTax>0.0</BaseAmountExclusiveTax>
+                            <BaseAmountInclusiveTax>0.0</BaseAmountInclusiveTax>
+                        </TaxDetail>
+                        <TotalTax>0.0</TotalTax>
+                    </Tax>
+                    <AmountInclusiveTax>0.0</AmountInclusiveTax>
+                    <AmountExclusiveTax>0.0</AmountExclusiveTax>
+                    <FixedReference>
+                        <ReferencePosition>4</ReferencePosition>
+                        <ReferenceType>OrderNumberBySupplier</ReferenceType>
+                        <ReferenceValue>Order123</ReferenceValue>
+                    </FixedReference>
+                    <FixedReference>
+                        <ReferencePosition>5</ReferencePosition>
+                        <ReferenceType>OrderNumberByBuyer</ReferenceType>
+                        <ReferenceValue>CustomerRef</ReferenceValue>
+                    </FixedReference>
+                </LineItem>
+                <LineItem>
+                    <LineItemType>NORMAL</LineItemType>
+                    <LineItemID>3</LineItemID>
+                    <ProductDescription>Phone support</ProductDescription>
+                    <Quantity>4.0</Quantity>
+                    <QuantityDescription>PCE</QuantityDescription>
+                    <PriceUnit>1</PriceUnit>
+                    <AmountInclusiveTax>0.0</AmountInclusiveTax>
+                    <AmountExclusiveTax>0.0</AmountExclusiveTax>
+                </LineItem>
+            </LineItems>
+            <Summary>
+                <Tax>
+                    <TaxDetail>
+                        <Rate>7.7</Rate>
+                        <Amount>37.88</Amount>
+                        <BaseAmountExclusiveTax>492.0</BaseAmountExclusiveTax>
+                        <BaseAmountInclusiveTax>529.88</BaseAmountInclusiveTax>
+                    </TaxDetail>
+                    <TotalTax>37.88</TotalTax>
+                </Tax>
+                <Discount>
+                  <Days>10</Days>
+                  <Rate>2.0</Rate>
+                </Discount>
+                <TotalAmountExclusiveTax>492.0</TotalAmountExclusiveTax>
+                <TotalAmountInclusiveTax>529.88</TotalAmountInclusiveTax>
+                <!-- <TotalAmountPaid>200.00</TotalAmountPaid> -->
+                <TotalAmountDue>529.88</TotalAmountDue>
+            </Summary>
+        </Bill>
+        <Appendix />
+    </Body>
+</Envelope>

--- a/ebill_postfinance/tests/test_ebill_postfinance_message_yb.py
+++ b/ebill_postfinance/tests/test_ebill_postfinance_message_yb.py
@@ -31,10 +31,9 @@ class TestEbillPostfinanceMessageYB(CommonCase):
         except Exception:
             _logger.info("Disabling moves on invoice lines.")
 
-    def test_invoice_qr(self):
-        """Check XML payload genetated for an invoice."""
+    def _test_invoice_qr(self, expected_tmpl):
+        """Check XML payload generated for an invoice."""
         self.invoice.name = "INV_TEST_01"
-        self.invoice.invoice_payment_term_id = self.payment_term
         message = self.invoice.create_postfinance_ebill()
         message.set_transaction_id()
         message.payload = message._generate_payload_yb()
@@ -49,9 +48,7 @@ class TestEbillPostfinanceMessageYB(CommonCase):
                 break
         payload = "\n".join(lines).encode("utf8")
         # Prepare the XML file that is expected
-        expected_tmpl = Template(
-            file_open("ebill_postfinance/tests/samples/invoice_qr_yb.xml").read()
-        )
+        expected_tmpl = Template(file_open(expected_tmpl).read())
         expected = expected_tmpl.substitute(
             TRANSACTION_ID=message.transaction_id, CUSTOMER_ID=self.customer.id
         ).encode("utf8")
@@ -59,3 +56,23 @@ class TestEbillPostfinanceMessageYB(CommonCase):
         payload = clean_xml(payload)
         expected = clean_xml(expected)
         self.assertFalse(self.compare_xml_line_by_line(payload, expected))
+
+    def test_invoice_qr(self):
+        """Check XML payload genetated for an invoice."""
+        self.invoice.invoice_payment_term_id = self.payment_term
+        self._test_invoice_qr("ebill_postfinance/tests/samples/invoice_qr_yb.xml")
+
+    def test_invoice_qr_discount(self):
+        payment_term = self.env["account.payment.term"].create(
+            {
+                "name": "Skonto",
+                "early_discount": True,
+                "discount_days": 10,
+                "discount_percentage": 2.0,
+            }
+        )
+        self.invoice.invoice_payment_term_id = payment_term
+        self.invoice.invoice_date_due = "2019-08-20"
+        self._test_invoice_qr(
+            "ebill_postfinance/tests/samples/invoice_qr_yb_discount.xml"
+        )


### PR DESCRIPTION
This was done with ebill_postfinance_financial_discount till v17
but now discounts are implemented in core.

FWD port of https://github.com/OCA/l10n-switzerland/pull/677