### PR TITLE
[IMP] ebill_postfinance: use residual_amount to calculate total

### DIFF
--- a/ebill_postfinance/messages/invoice-yellowbill.jinja
+++ b/ebill_postfinance/messages/invoice-yellowbill.jinja
@@ -216,8 +216,8 @@
                 {# </Discount> #}
                 <TotalAmountExclusiveTax>{{ invoice.amount_untaxed * amount_sign }}</TotalAmountExclusiveTax>
                 <TotalAmountInclusiveTax>{{ invoice.amount_total * amount_sign }}</TotalAmountInclusiveTax>
-                {# <TotalAmountPaid></TotalAmountPaid> #}
-                <TotalAmountDue>{{ invoice.amount_total * amount_sign }}</TotalAmountDue>
+                <TotalAmountPaid>{{ (invoice.amount_total - invoice.amount_residual) * amount_sign }}</TotalAmountPaid>
+                <TotalAmountDue>{{ invoice.amount_residual * amount_sign }}</TotalAmountDue>
             </Summary>
         </Bill>
         <Appendix>

--- a/ebill_postfinance/tests/examples/credit_note_yb.xml
+++ b/ebill_postfinance/tests/examples/credit_note_yb.xml
@@ -166,7 +166,7 @@
                 </Tax>
                 <TotalAmountExclusiveTax>-492.0</TotalAmountExclusiveTax>
                 <TotalAmountInclusiveTax>-529.88</TotalAmountInclusiveTax>
-                <!-- <TotalAmountPaid>200.00</TotalAmountPaid> -->
+                <TotalAmountPaid>-0.0</TotalAmountPaid>
                 <TotalAmountDue>-529.88</TotalAmountDue>
             </Summary>
           </Bill>

--- a/ebill_postfinance/tests/examples/invoice_qr_yb.xml
+++ b/ebill_postfinance/tests/examples/invoice_qr_yb.xml
@@ -172,7 +172,7 @@
                 </Tax>
                 <TotalAmountExclusiveTax>492.0</TotalAmountExclusiveTax>
                 <TotalAmountInclusiveTax>529.88</TotalAmountInclusiveTax>
-                <!-- <TotalAmountPaid>200.00</TotalAmountPaid> -->
+                <TotalAmountPaid>0.0</TotalAmountPaid>
                 <TotalAmountDue>529.88</TotalAmountDue>
             </Summary>
           </Bill>

--- a/ebill_postfinance_stock/tests/examples/invoice_qr_yb.xml
+++ b/ebill_postfinance_stock/tests/examples/invoice_qr_yb.xml
@@ -182,7 +182,7 @@
                 </Tax>
                 <TotalAmountExclusiveTax>492.0</TotalAmountExclusiveTax>
                 <TotalAmountInclusiveTax>529.88</TotalAmountInclusiveTax>
-                <!-- <TotalAmountPaid>200.00</TotalAmountPaid> -->
+                <TotalAmountPaid>0.0</TotalAmountPaid>
                 <TotalAmountDue>529.88</TotalAmountDue>
             </Summary>
           </Bill>


### PR DESCRIPTION
The `TotalAmountDue` in the yellowBill XML now uses `invoice.amount_residual` in order to bill the remaining amount instead of the total amount in case the partner already has made partial payment. It also adds the `TotalAmountPaid` field to the XML, though I couldn't see any user-facing effects in the E-Bill portal regarding that.


Implementation Notes:
 - This has been tested with a real eBill sent to Postfinance in the production environment
 - The automatic tests don't actually include any credit notes / partial payment, might be worth improving
 - I only changed the yellowbill template but not the 2003A template, because I wasn't sure how it works. I'm not really sure if that format is actually used by users


General Notes:
 - This is my first contribution to an OCA module. I tried to follow all the guidelines but let me know if I missed something. One thing that confused me is the `setup` directory in the repo, which seems to contain the whole source code again. I have not made any changes there.
 - I submit this for version 16.0 since that's what we're using. I had a quick look at the other versions and I think this should be easily forward-portable.