### PR TITLE
[18.0][IMP] ebill_postfinance: add config for xml file language

### DIFF
--- a/ebill_postfinance/models/ebill_postfinance_invoice_message.py
+++ b/ebill_postfinance/models/ebill_postfinance_invoice_message.py
@@ -324,8 +324,16 @@ class EbillPostfinanceInvoiceMessage(models.Model):
     def _get_template_yb(self, jinja_env):
         return jinja_env.get_template(INVOICE_TEMPLATE_YB)
 
+    def _get_xml_language_code(self):
+        if self.service_id.xml_file_language:
+            return self.service_id.xml_file_language.code
+        if self.ebill_payment_contract_id.partner_id.lang:
+            return self.ebill_payment_contract_id.partner_id.lang
+        return self.env.lang.code
+
     def _generate_payload(self):
         self.ensure_one()
+        self = self.with_context(lang=self._get_xml_language_code())
         assert self.state in ("draft", "error")
         if self.service_id.file_type_to_use == "XML":
             if self.service_id.use_file_type_xml_paynet:

--- a/ebill_postfinance/models/ebill_postfinance_service.py
+++ b/ebill_postfinance/models/ebill_postfinance_service.py
@@ -57,6 +57,12 @@ class EbillPostfinanceService(models.Model):
         default="600",
         help="Timeout for each HTTP (GET, POST) request in seconds.",
     )
+    xml_file_language = fields.Many2one(
+        comodel_name="res.lang",
+        string="XML file Language",
+        help="The language used to generate the XML file, "
+        "if unset default to the customer language.",
+    )
 
     def _get_service(self):
         return ebilling_postfinance.WebService(

--- a/ebill_postfinance/views/ebill_postfinance_service.xml
+++ b/ebill_postfinance/views/ebill_postfinance_service.xml
@@ -75,6 +75,7 @@
                             <field name="use_test_service" />
                             <field name="operation_timeout" />
                             <field name="file_type_to_use" readonly="1" />
+                            <field name="xml_file_language" />
                             <field
                                 name="use_file_type_xml_paynet"
                                 invisible="file_type_to_use != 'XML'"


### PR DESCRIPTION
The language used to generate the xml file can affect the invoice line description, the uom description and possibly between other.

Before this change the default language of the user click the Export button would be used.

Now priority is on the configuration of the service, if not set the language of the customer and then the default environment language.