### PR TITLE
[16.0][FIX]ebill*: Use SEPA compliant BIC for test

### DIFF
--- a/ebill_postfinance/tests/common.py
+++ b/ebill_postfinance/tests/common.py
@@ -40,7 +40,7 @@ class CommonCase(TransactionCase, XmlTestMixin):
         cls.company.email = "info@camptocamp.com"
         cls.company.phone = ""
         cls.bank = cls.env.ref("base.res_bank_1")
-        cls.bank.bic = 777
+        cls.bank.bic = "POFICHBEXXX"
         cls.tax7 = cls.env.ref("l10n_ch.{}_vat_77".format(cls.company.id))
         cls.partner_bank = cls.env["res.partner.bank"].create(
             {

--- a/ebill_postfinance/tests/examples/invoice_qr_yb.xml
+++ b/ebill_postfinance/tests/examples/invoice_qr_yb.xml
@@ -80,7 +80,7 @@
                     <PaymentType>IBAN</PaymentType>
                     <fixAmount>Yes</fixAmount>
                     <IBAN>
-                        <BIC>777</BIC>
+                        <BIC>POFICHBEXXX</BIC>
                         <BankName>Reserve</BankName>
                         <IBAN>CH2130808001234567827</IBAN>
                         <CreditorReference>210000000003139471430009017</CreditorReference>

--- a/ebill_postfinance_stock/tests/examples/invoice_qr_yb.xml
+++ b/ebill_postfinance_stock/tests/examples/invoice_qr_yb.xml
@@ -80,7 +80,7 @@
                     <PaymentType>IBAN</PaymentType>
                     <fixAmount>Yes</fixAmount>
                     <IBAN>
-                        <BIC>777</BIC>
+                        <BIC>POFICHBEXXX</BIC>
                         <BankName>Reserve</BankName>
                         <IBAN>CH2130808001234567827</IBAN>
                         <CreditorReference>210000000003139471430009017</CreditorReference>


### PR DESCRIPTION
Hello,

While migrating pain modules, we encountered an issue with test data BIC being not compliant with SEPA.
see #754 
