### PR TITLE
ebill_postfinance: fix, ReasonCode might be empty

### DIFF
--- a/ebill_postfinance/models/ebill_postfinance_invoice_message.py
+++ b/ebill_postfinance/models/ebill_postfinance_invoice_message.py
@@ -127,7 +127,7 @@ class EbillPostfinanceInvoiceMessage(models.Model):
         """
         self.ensure_one()
         self.server_state = data.State.lower()
-        self.server_reason_code = int(data.ReasonCode)
+        self.server_reason_code = data.ReasonCode and int(data.ReasonCode) or False
         self.server_reason_text = data.ReasonText
         if self.server_state in ["invalid"]:
             self.state = "error"


### PR DESCRIPTION
Fixes previous change:
- OCA/l10n-switzerland#781

`ReasonCode` can be `None` and `int(None)` raises TypeError